### PR TITLE
[Feat] Common button 컴포넌트 수정

### DIFF
--- a/components/common/CommonButton.tsx
+++ b/components/common/CommonButton.tsx
@@ -7,7 +7,25 @@ interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   children?: React.ReactNode;
   width?: string;
   className?: string;
+  type?: 'button' | 'submit' | 'reset';
 }
+
+function CommonButton({
+  size = 'L',
+  variant = 'primary',
+  children,
+  width,
+  className,
+  type = 'button',
+  ...rest
+}: Props) {
+  return (
+    <button type={type} className={clsx(SIZE_MAP[size], VARIANT_MAP[variant ?? 'primary'], width, className)} {...rest}>
+      {children}
+    </button>
+  );
+}
+
 const SIZE_MAP: {
   L: string;
   M: string;
@@ -24,13 +42,7 @@ const VARIANT_MAP: {
   primary:
     'border border-nomad-black bg-nomad-black text-white font-bold text-center disabled:border-gray-600 disabled:bg-gray-600 disabled:text-white',
   secondary:
-    'border border-nomad-black text-nomad-black font-bold text-center  disabled:border-gray-600 disabled:bg-gray-600 disabled:text-white',
+    'border border-nomad-black text-nomad-black font-bold text-center disabled:border-gray-600 disabled:bg-gray-600 disabled:text-white',
 };
-function commonButton({ size = 'L', variant = 'primary', children, width, className, ...rest }: Props) {
-  return (
-    <button className={clsx(SIZE_MAP[size], VARIANT_MAP[variant ?? 'primary'], width, className)} {...rest}>
-      {children}
-    </button>
-  );
-}
-export default commonButton;
+
+export default CommonButton;

--- a/components/common/CommonButton.tsx
+++ b/components/common/CommonButton.tsx
@@ -1,0 +1,36 @@
+import { ButtonHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  size: 'L' | 'M' | 'S';
+  variant?: 'primary' | 'secondary';
+  children?: React.ReactNode;
+  width?: string;
+  className?: string;
+}
+const SIZE_MAP: {
+  L: string;
+  M: string;
+  S: string;
+} = {
+  L: 'p-[11px] h-[56px] lg-bold',
+  M: 'p-[11px] h-[48px] lg-bold',
+  S: 'p-[8px] h-[38px] md-bold',
+};
+const VARIANT_MAP: {
+  primary: string;
+  secondary: string;
+} = {
+  primary:
+    'border border-nomad-black bg-nomad-black text-white font-bold text-center disabled:border-gray-600 disabled:bg-gray-600 disabled:text-white',
+  secondary:
+    'border border-nomad-black text-nomad-black font-bold text-center  disabled:border-gray-600 disabled:bg-gray-600 disabled:text-white',
+};
+function commonButton({ size = 'L', variant = 'primary', children, width, className, ...rest }: Props) {
+  return (
+    <button className={clsx(SIZE_MAP[size], VARIANT_MAP[variant ?? 'primary'], width, className)} {...rest}>
+      {children}
+    </button>
+  );
+}
+export default commonButton;


### PR DESCRIPTION
## ✨ PR 개요

> Common button 컴포넌트 수정

## 🧩 PR 요약

- [x] 공통 버튼 컴포넌트 수정 반영하였습니다. (https://github.com/CIrcle0616/global_nomad/pull/14#issue-3095730486)

## 🎯 작업 내용 상세 (요구사항 확인)

- [x]  ops로 size, variant, children, width, className 값을 받음 
- [x] 스타일은 primary와 secondary 두 가지. 스타일은 primary로 기본 설정
- [x] 사이즈는 height 로 구분됨.  "L" (56px), "M"( 48px), "S" (38px)
 - [x] width 값은 설정되지 않음  태그 내에서 "width"  속성을 통해서 개별 설정 가능 (tailwind 클래스 사용 필수)
- [x] 나머지 onclick이나 접근성등 기타 설정이 필요한 경우에는  기존 사용법대로 추가 가능
- [x] clsx 를 통해서 클래스 명 조합됨
- 버튼 컴포넌트 가이드 작성 (https://www.notion.so/CommonButton-200b8f3dcf4e80478332c8c43dab5f29?pvs=4)  

## 📸 스크린샷 (선택)

> UI 변경이 있는 경우 추가

|         기능      |          스크린샷          |
| -------------- | --------------------- |
| 버튼 컴포넌트 | ![image](https://github.com/user-attachments/assets/2748f89e-534f-47fc-b243-2802da8abc34) |

## 🔗 관련 이슈 (선택)

> 

## 💬 기타 전달 사항 (선택)

> 기존 브랜치 충돌로 새 브랜치에서 반영해서 다시 PR 작성하였습니다. 
