### PR TITLE
[Feat] ProfileImageUploader 컴포넌트 분리 및 SideProfile 리팩토링

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <Providers>
           {children}
           {/* 전역 모달 컴포넌트 위치 */}
-          <OneButtonModal />
+          <GlobalModal />
         </Providers>
       </body>
     </html>

--- a/components/common/ProfileImageUploader.tsx
+++ b/components/common/ProfileImageUploader.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import Image from 'next/image';
+import { useRef, useState } from 'react';
+
+export default function ProfileImageUploader() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [profileUrl, setProfileUrl] = useState('/ic_profile.svg');
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const url = URL.createObjectURL(file);
+      setProfileUrl(url);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center mb-6">
+      <div className="relative w-[160px] h-[160px] mb-3">
+        <Image src={profileUrl} alt="프로필 이미지" fill className="rounded-full object-cover" />
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          className="absolute bottom-2 right-2 w-11 h-11 bg-green-700 rounded-full flex items-center justify-center"
+        >
+          <Image src="/ic_pen.svg" alt="편집" width={44} height={44} />
+        </button>
+        <input type="file" accept="image/*" ref={fileInputRef} onChange={handleImageChange} className="hidden" />
+      </div>
+      <p className="font-semibold text-base">프로필 이미지</p>
+    </div>
+  );
+}

--- a/components/layout/SideProfile.tsx
+++ b/components/layout/SideProfile.tsx
@@ -3,7 +3,7 @@
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
-import { useRef, useState } from 'react';
+import ProfileImageUploader from '@/components/common/ProfileImageUploader';
 
 const menuItems = [
   {
@@ -34,33 +34,10 @@ const menuItems = [
 
 export default function SideProfile() {
   const pathname = usePathname();
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [profileUrl, setProfileUrl] = useState('/ic_profile.svg');
-
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      const url = URL.createObjectURL(file);
-      setProfileUrl(url);
-    }
-  };
 
   return (
     <div className="bg-white border border-gray-300 rounded-xl shadow-md p-6 w-full h-fit shrink-0">
-      <div className="flex flex-col items-center mb-6">
-        <div className="relative w-[160px] h-[160px] mb-3">
-          <Image src={profileUrl} alt="프로필 이미지" fill className="rounded-full object-cover" />
-          <button
-            type="button"
-            onClick={() => fileInputRef.current?.click()}
-            className="absolute bottom-2 right-2 w-11 h-11 bg-green-700 rounded-full flex items-center justify-center"
-          >
-            <Image src="/ic_pen.svg" alt="편집" width={44} height={44} />
-          </button>
-          <input type="file" accept="image/*" ref={fileInputRef} onChange={handleImageChange} className="hidden" />
-        </div>
-        <p className="font-semibold text-base">프로필 이미지</p>
-      </div>
+      <ProfileImageUploader />
 
       <ul className="space-y-2 w-full">
         {menuItems.map(({ name, path, icon, iconGray }) => {


### PR DESCRIPTION
## ✨ PR 개요
사이드 프로필의 이미지 업로드를 컴포넌트로 분리하여 코드의 가독성과 재사용 및 유지보수성 향상시킴.

## 🧩 PR 요약

- [ ] 새로운 기능 추가
- [x] 리팩토링

## 🎯 작업 내용 상세 (요구사항 확인)

- [x] 이미지 업로드를 컴포넌트로 분리함
- [x] layout에서 변수명 오류로 교체함 

## 📸 스크린샷 (선택)

> UI 변경이 있는 경우 추가

| 기능      | 스크린샷              |
| --------- | --------------------- |
| 팀생성 폼 | ![image](이미지 주소) |

## 🔗 관련 이슈 (선택)

> ex) #123 - 모달 UI 문제 이슈

## 💬 기타 전달 사항 (선택)

> 고민 중인 포인트나 논의가 필요한 부분이 있다면 작성해주세요.
