### PR TITLE
[Feat] 카카오 로그인 연결 반환되는 토큰 쿠키로 세팅

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,0 +1,8 @@
+namespace NodeJS {
+  interface ProcessEnv {
+    KAKAO_REDIRECT_URL: string;
+    KAKAO_REST_API_KEY: string;
+    OAUTH_SIGN_IN_API_URL: string;
+    SIGN_UP_URL: string;
+  }
+}

--- a/app/oauth/callback/client-processing/page.tsx
+++ b/app/oauth/callback/client-processing/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { getUserMe } from '@/services/users';
+import { GetMyInfoSuccessResponse } from '@/types/domain/user/types';
+import { useQuery } from '@tanstack/react-query';
+
+export default function OauthHandlerPage() {
+  const { data } = useQuery<GetMyInfoSuccessResponse>({
+    queryKey: ['users'],
+    queryFn: async () => {
+      const user = await getUserMe();
+      return user;
+    },
+    retry: 3,
+  });
+
+  return <h1>{data?.id}</h1>;
+}

--- a/app/oauth/kakao/route.ts
+++ b/app/oauth/kakao/route.ts
@@ -1,0 +1,119 @@
+import { SignInOauthSuccessResponse } from '@/types/domain/oAuth/types';
+import { NextRequest, NextResponse } from 'next/server'; // Next.js 서버 요청 및 응답 객체
+
+//인증 성공 시 처리 함수
+function handleAuthSuccess(oAuthData: SignInOauthSuccessResponse, request: NextRequest) {
+  const targetUrl = new URL('/oauth/callback/client-processing', request.url);
+  const response = NextResponse.redirect(targetUrl);
+
+  // 액세스 토큰 쿠키로 설정
+  if (oAuthData.accessToken) {
+    response.cookies.set('accessToken', oAuthData.accessToken, {
+      httpOnly: true, // JavaScript에서 접근 불가 (XSS 방지)
+      secure: process.env.NODE_ENV === 'production', // 프로덕션 환경에서는 HTTPS에서만 전송
+      sameSite: 'lax', // CSRF 공격 방지를 위해 'lax' 또는 'strict' 권장
+      path: '/', // 웹사이트 전체 경로에서 사용 가능
+      maxAge: 60 * 60 * 6, // 쿠키 만료 시간 (6시간)
+    });
+  }
+
+  // 리프레시 토큰 쿠키로 설정
+  if (oAuthData.refreshToken) {
+    response.cookies.set('refreshToken', oAuthData.refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 60 * 60 * 60, // 쿠키 만료 시간 (60시간, 예시) - 실제 서비스의 정책에 맞게 설정
+    });
+  }
+
+  return response;
+}
+
+//GET 요청 핸들러 (OAuth 콜백 처리)
+//카카오 등 OAuth 제공자로부터 리다이렉트되어 호출됩니다.
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const code = searchParams.get('code'); // 'code' 파라미터(카카오로부터 받은 인가 코드) 가져오기
+  const redirectUri = process.env.KAKAO_REDIRECT_URL;
+  console.log('카카오 OAuth 콜백 실행됨');
+
+  if (!code) {
+    return NextResponse.json({ error: '인가 코드가 없습니다' }, { status: 400 });
+  }
+
+  try {
+    const oAuthResponse = await fetch(process.env.OAUTH_SIGN_IN_API_URL!, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        redirectUri,
+        token: code,
+      }),
+    });
+
+    // 1-1. 자체 백엔드 로그인 API 호출 성공 시
+    if (oAuthResponse.ok) {
+      const oAuthData: SignInOauthSuccessResponse = await oAuthResponse.json();
+      console.log('카카오 로그인 성공 (자체 백엔드 API)', oAuthData.user);
+      return handleAuthSuccess(oAuthData, request);
+    } else {
+      // 1-2. 자체 백엔드 로그인 API 호출 실패 시 (예: 사용자가 존재하지 않는 경우 - 404)
+      const errorStatus = oAuthResponse.status;
+      if (errorStatus === 404) {
+        console.log('자체 백엔드에 사용자 없음 (404). 카카오 토큰 직접 요청 및 회원가입 시도.');
+
+        // 2. 카카오 OAuth 토큰 직접 요청 (ID 토큰 등 사용자 정보 획득 목적)
+        const clientId = process.env.KAKAO_REST_API_KEY;
+
+        const tokenRequestBody = new URLSearchParams({
+          /* eslint-disable camelcase */
+          grant_type: 'authorization_code',
+          client_id: clientId!,
+          redirect_uri: redirectUri!,
+          code,
+        });
+
+        // 카카오 토큰 발급 API 호출
+        const tokenResponse = await fetch('https://kauth.kakao.com/oauth/token', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+          },
+          body: tokenRequestBody.toString(),
+        });
+
+        const kakaoData = await tokenResponse.json();
+        const { id_token: idToken } = kakaoData;
+        const nickname = idToken;
+
+        // 3. 자체 백엔드의 회원가입 API 호출
+        const signUpResponse = await fetch(process.env.SIGN_UP_URL!, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            redirectUri,
+            nickname,
+            token: code,
+          }),
+        });
+
+        // 3-1. 자체 백엔드 회원가입 API 호출 성공 시
+        if (signUpResponse.ok) {
+          const oAuthData: SignInOauthSuccessResponse = await signUpResponse.json();
+          console.log('카카오 회원가입 후 로그인 성공 (자체 백엔드 API)', oAuthData.user);
+          return handleAuthSuccess(oAuthData, request);
+        }
+      }
+    }
+  } catch (error) {
+    // 전체 try-catch 블록에서 발생한 예외 처리
+    console.error('카카오 OAuth 콜백 처리 중 에러:', error);
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+}

--- a/components/domain/auth/KakaoOauthLink.tsx
+++ b/components/domain/auth/KakaoOauthLink.tsx
@@ -3,7 +3,10 @@ import Link from 'next/link';
 
 export default function KakaoOauthLink() {
   return (
-    <Link href={'/카카오 로그인 주소'} className="relative inline-block w-full h-full">
+    <Link
+      href={`https://kauth.kakao.com/oauth/authorize?client_id=${process.env.KAKAO_REST_API_KEY}&redirect_uri=${process.env.KAKAO_REDIRECT_URL}&response_type=code`}
+      className="relative inline-block w-full h-full"
+    >
       <Image src="/img_kakao.svg" fill alt="카카오 로그인" />
     </Link>
   );

--- a/components/domain/auth/LoginForm.tsx
+++ b/components/domain/auth/LoginForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import OneButtonModal from '@/components/common/modal/OneButtonModal';
 import { HttpError } from '@/constants/utils/errors';
 import { loginUser } from '@/services/auth';
 import { useModalStore } from '@/store/modalStore';
@@ -26,7 +27,7 @@ export default function LoginForm() {
     register,
     handleSubmit,
     formState: { errors, isValid },
-  } = useForm<LoginInputs>({ mode: 'onChange' });
+  } = useForm<LoginInputs>({ mode: 'onBlur' });
 
   const loginMutation = useMutation<LoginSuccessResponse, HttpError, LoginInputs>({
     mutationFn: credentials => {
@@ -39,14 +40,13 @@ export default function LoginForm() {
     onError: error => {
       const { status } = error;
       if (status === 404) {
-        openModal('oneButton', {
+        openModal(OneButtonModal, {
           content: '존재하지 않는 유저입니다.',
-          onConfirm: () => console.log('존재하지 않는 유저입니다.'),
+          onConfirm: () => router.push('/'),
         });
       } else {
-        openModal('oneButton', {
+        openModal(OneButtonModal, {
           content: error.message,
-          onConfirm: () => console.log(`로그인 에러: ${error.message}`),
         });
       }
     },

--- a/components/domain/auth/LoginForm.tsx
+++ b/components/domain/auth/LoginForm.tsx
@@ -2,7 +2,7 @@
 
 import { HttpError } from '@/constants/utils/errors';
 import { loginUser } from '@/services/auth';
-import { useModalStore } from '@/store';
+import { useModalStore } from '@/store/modalStore';
 import { useAuthStore } from '@/store/useAuthStore';
 import { LoginSuccessResponse } from '@/types/domain/auth/types';
 import { useMutation } from '@tanstack/react-query';

--- a/components/domain/auth/SignUpForm.tsx
+++ b/components/domain/auth/SignUpForm.tsx
@@ -2,7 +2,7 @@
 
 import { HttpError } from '@/constants/utils/errors';
 import { signUp } from '@/services/users';
-import { useModalStore } from '@/store';
+import { useModalStore } from '@/store/modalStore';
 import { CreateUserBodyDto } from '@/types';
 import { CreateUserSuccessResponse } from '@/types/domain/user/types';
 import { useMutation } from '@tanstack/react-query';

--- a/components/domain/auth/SignUpForm.tsx
+++ b/components/domain/auth/SignUpForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import OneButtonModal from '@/components/common/modal/OneButtonModal';
 import { HttpError } from '@/constants/utils/errors';
 import { signUp } from '@/services/users';
 import { useModalStore } from '@/store/modalStore';
@@ -26,7 +27,7 @@ export default function SignUpForm() {
     handleSubmit,
     watch,
     formState: { errors, isValid },
-  } = useForm<SignUpFormInputs>({ mode: 'onChange' });
+  } = useForm<SignUpFormInputs>({ mode: 'onBlur' });
 
   const passwordValue = watch('password');
 
@@ -35,22 +36,19 @@ export default function SignUpForm() {
       return signUp(credentials);
     },
     onSuccess: () => {
-      openModal('oneButton', {
+      openModal(OneButtonModal, {
         content: '가입이 완료되었습니다!',
         onConfirm: () => router.push('/'),
-        buttonText: '확인',
       });
     },
     onError: error => {
       const { status } = error;
       if (status === 409) {
-        openModal('oneButton', {
+        openModal(OneButtonModal, {
           content: '이미 사용중인 이메일입니다.',
-          onConfirm: () => console.log('중복이메일'),
-          buttonText: '확인',
         });
       } else {
-        openModal('oneButton', { content: error.message, onConfirm: () => console.log('에러'), buttonText: '확인' });
+        openModal(OneButtonModal, { content: error.message });
       }
     },
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,0 @@
-/*
-리액트 쿼리나 기타 util 함수등을 보관하는 폴더입니다. queryClient.ts설정 같은 것, 
-Math.floor(Math.random() + 10) + 1 과 같은 순수 js util함수 같은 것들을 보관 합니다.
-*/

--- a/services/fetchWrapper.ts
+++ b/services/fetchWrapper.ts
@@ -27,6 +27,7 @@ export async function fetchWrapper<T>(
     method,
     headers,
     body: isFormData ? body : body ? JSON.stringify(body) : undefined,
+    credentials: 'include', // 설정했는데 CORS에러 발생 -> api proxy 서버 필요
   });
 
   if (response.status === 204) {


### PR DESCRIPTION
## 🧩 PR 요약

- [x] 새로운 기능 추가
- [ ] 버그 수정

## 🎯 작업 내용 상세 (요구사항 확인)

카카오 로그인 로직
-> 로그인 페이지나 회원가입 페이지에서 카카오가 제공하는 설정에 따라 제공하는 url로 이동
-> 로그인 또는 회원가입 진행시 인가코드를 redirectUrl로 주소창에 포함 시켜 이동시킴
<img width="2672" alt="스크린샷 2025-06-05 오전 2 24 27" src="https://github.com/user-attachments/assets/ef81d5ba-2a4f-4dd9-b56b-8de2a2d8a2be" />
오른쪽 네트워크 요청을 보면 302 상태로 다음 주소로 리다이렉트 시킨다.
`http://localhost:3000/oauth/kakao?code=qs4HFEgKX_nVTafaXoVJAIDK1RdCMpwfYepEBM6-3bzKdOMp6eQS1AAAAAQKDSHZAAABlzv4fJim1x-HnlkNwQ`
-> Next.js의 api 기능을 사용해서 해당 주소로 이동시(GET)요청 시 동작시킬 함수들을 `app/oauth/kakao/route.ts에 작성했다.
-> route.ts파일 안에서 또 api요청을 반복하고 최종적으로 클라이언트에서 user 데이터와 로그인 처리를 진행할 app/oauth/client-processing/page.tsx로 리다이렉트 시킨 상태이다.

결론: 로그인 기능은 정상동작함 추가적으로 기타 api요청을 proxy 서버를 이용해 로그인 시 세팅된 쿠키를 자동 첨부하여 api요청시 권한 인가가 가능하도록 수정할 필요가 있음

> 테스트를 원하신다면 /login으로 이동하셔서 카카오 버튼을 클릭하면 자동 진행됩니다!

## 📸 스크린샷 (선택)

> UI 변경이 있는 경우 추가

## 🔗 관련 이슈 (선택)

> #25 

## 💬 기타 전달 사항 (선택)

> 고민 중인 포인트나 논의가 필요한 부분이 있다면 작성해주세요.
