### PR TITLE
[Feat] 내정보 페이지 작업

### DIFF
--- a/app/profile/info/page.tsx
+++ b/app/profile/info/page.tsx
@@ -1,3 +1,5 @@
-export default function ProfileInfoPage() {
-  return <h1 className="text-3xl-bold mb-6 ml-4">내 정보</h1>;
+import MyInfoForm from '@/components/domain/profile/MyInfoForm';
+
+export default function MyInfoPage() {
+  return <MyInfoForm />;
 }

--- a/components/domain/profile/MyInfoForm.tsx
+++ b/components/domain/profile/MyInfoForm.tsx
@@ -130,10 +130,6 @@ export default function MyInfoPage() {
               rules={{
                 required: '비밀번호를 입력해주세요.',
                 minLength: { value: 8, message: '8자 이상 입력해 주세요.' },
-                pattern: {
-                  value: /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$/,
-                  message: '영문과 숫자를 포함해 주세요.',
-                },
               }}
               control={control}
               render={({ field }) => (

--- a/components/domain/profile/MyInfoForm.tsx
+++ b/components/domain/profile/MyInfoForm.tsx
@@ -1,0 +1,174 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { useQueryClient, useMutation, useQuery } from '@tanstack/react-query';
+import { getUserMe, patchUserMe } from '@/services/users';
+import { UpdateUserBodyDto } from '@/types';
+import { GetMyInfoSuccessResponse } from '@/types/domain/user/types';
+import { useForm, SubmitHandler, Controller } from 'react-hook-form';
+import Input from '@/components/common/Input';
+import CommonButton from '@/components/common/CommonButton';
+import ProfileImageUploader from '@/components/common/ProfileImageUploader';
+
+type userInfoInputs = UpdateUserBodyDto & {
+  passwordConfirm: string;
+};
+
+export default function MyInfoPage() {
+  const queryClient = useQueryClient();
+
+  const [email, setEmail] = useState('');
+
+  const { data, isSuccess, isError, error } = useQuery({
+    queryKey: ['myInfo'],
+    queryFn: () => {
+      return getUserMe();
+    },
+  });
+
+  const {
+    control,
+    handleSubmit,
+    getValues,
+    formState: { errors },
+    reset,
+  } = useForm<userInfoInputs>({
+    mode: 'onChange',
+    defaultValues: {
+      nickname: '',
+      newPassword: '',
+      passwordConfirm: '',
+    },
+  });
+
+  const profileInfoMutation = useMutation<GetMyInfoSuccessResponse, Error, UpdateUserBodyDto>({
+    mutationFn: profileInfo => {
+      return patchUserMe(profileInfo);
+    },
+    onSuccess: () => {
+      alert('내정보가 수정되었습니다.');
+      queryClient.invalidateQueries({ queryKey: ['myInfo'] });
+    },
+    onError: error => {
+      console.log(error);
+    },
+  });
+
+  const onSubmit: SubmitHandler<userInfoInputs> = data => {
+    const { nickname, newPassword } = data;
+    profileInfoMutation.mutate({ nickname, newPassword });
+  };
+
+  useEffect(() => {
+    if (isSuccess && data) {
+      reset({
+        nickname: data.nickname,
+        newPassword: '',
+        passwordConfirm: '',
+      });
+      setEmail(data.email);
+    }
+  }, [data, isSuccess, reset]);
+
+  if (isError) {
+    console.error('에러 내용:', error);
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div className="px-6 mb-[120px]">
+        <div className="flex justify-between items-center mb-4">
+          <h1 className="text-3xl-bold text-black">내 정보</h1>
+          <CommonButton size="M" type="submit" width="w-[120px]">
+            저장하기
+          </CommonButton>
+        </div>
+
+        <section className="space-y-6">
+          <div className="md:hidden">
+            <ProfileImageUploader />
+          </div>
+          <div>
+            <label className="block mb-4 text-2xl-bold text-black" htmlFor="nickname">
+              닉네임
+            </label>
+            <Controller
+              name="nickname"
+              control={control}
+              defaultValue=""
+              rules={{
+                required: '닉네임을 입력해주세요.',
+              }}
+              render={({ field }) => (
+                <Input
+                  value={field.value ?? ''}
+                  onChange={field.onChange}
+                  placeholder="닉네임을 입력해주세요."
+                  error={errors.nickname?.message}
+                />
+              )}
+            />
+          </div>
+
+          <div>
+            <label className="block mb-4 text-2xl-bold text-black" htmlFor="email">
+              이메일
+            </label>
+            <Input
+              value={email || ''}
+              onChange={e => setEmail(e.target.value)}
+              placeholder="이메일을 입력해주세요."
+              readOnly
+            />
+          </div>
+
+          <div>
+            <label className="block mb-4 text-2xl-bold text-black" htmlFor="password">
+              비밀번호
+            </label>
+            <Controller
+              name="newPassword"
+              rules={{
+                required: '비밀번호를 입력해주세요.',
+                minLength: { value: 8, message: '8자 이상 입력해 주세요.' },
+                pattern: {
+                  value: /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$/,
+                  message: '영문과 숫자를 포함해 주세요.',
+                },
+              }}
+              control={control}
+              render={({ field }) => (
+                <Input
+                  {...field}
+                  value={field.value ?? ''}
+                  onChange={field.onChange}
+                  placeholder="8자 이상 입력해 주세요."
+                  error={errors.newPassword?.message}
+                />
+              )}
+            />
+          </div>
+
+          <div>
+            <label className="block mb-4 text-2xl-bold text-black" htmlFor="confirmPassword">
+              비밀번호 재입력
+            </label>
+            <Controller
+              name="passwordConfirm"
+              control={control}
+              rules={{
+                validate: value => value === getValues('newPassword') || '비밀번호가 일치하지 않습니다.',
+              }}
+              render={({ field }) => (
+                <Input
+                  {...field}
+                  placeholder="비밀번호를 한번 더 입력해 주세요."
+                  error={errors.passwordConfirm?.message}
+                />
+              )}
+            />
+          </div>
+        </section>
+      </div>
+    </form>
+  );
+}

--- a/services/users.ts
+++ b/services/users.ts
@@ -22,9 +22,9 @@ export function getUserMe(): Promise<GetMyInfoSuccessResponse> {
 
 // 내 정보 수정
 export function patchUserMe(body: {
-  nickname: string;
-  profileImageUrl: string;
-  newPassword: string;
+  nickname?: string;
+  profileImageUrl?: string | null;
+  newPassword?: string;
 }): Promise<UpdateMyInfoSuccessResponse> {
   return fetchWrapper<UpdateMyInfoSuccessResponse>(`/users/me`, 'PATCH', body);
 }


### PR DESCRIPTION
## ✨ PR 개요

>내정보 페이지 작업

## 🧩 PR 요약

- [x] 새로운 기능 추가
- [ ] 버그 수정

## 🎯 작업 내용 상세 (요구사항 확인)

- 닉네임, 비밀번호, 비밀번호 확인 필드 구현 : react-hook-form와 Controller로 폼 구성

- useQuery 이용해서 데이터 로딩 : 내 정보 불러오기 API(getUserMe)에서 내정보 관련 데이터를 불러온다.

- useMutation 사용해서 데이터 변경 : patchUserMe API를 이용하여, 닉네임, 비밀번호를 바꾸고 '수정하기' 버튼을 누르면 수정

- validation 추가 : 닉네임, 비밀번호, 비밀번호 확인 필수값 지정, 비밀번호 유효성, 비밀번호와 비밀번호 확인 필드 일치 여부 검사


## 📸 스크린샷 (선택)

| 기능      | 스크린샷              |
| --------- | --------------------- |
| 내정보    | ![image](https://github.com/user-attachments/assets/13d2c796-5c33-488e-b3c0-e2a21a0febe7) |
![image](https://github.com/user-attachments/assets/413a3a2d-579f-43cb-ae22-9a59444bf0bf)

## 🔗 관련 이슈 (선택)

> https://github.com/CIrcle0616/global_nomad/issues/61

## 💬 기타 전달 사항 (선택)

> 고민 중인 포인트나 논의가 필요한 부분이 있다면 작성해주세요.

