### PR TITLE
[Fix] 무한 스크롤 및 API 호출(queryFn, patch, post) 로직 수정

### DIFF
--- a/components/domain/reservation/ClientReservations.tsx
+++ b/components/domain/reservation/ClientReservations.tsx
@@ -11,15 +11,11 @@ import DropdownMenu from '@/components/common/DropDown';
 
 import { filterOptions } from '@/constants/filterOption';
 import { getMyReservations } from '@/services/myReservations';
-import { Reservation } from '@/types/domain/myReservations/types';
 
 const PAGE_SIZE = 10;
-const INITIAL_RENDER_COUNT = 5;
 
 export default function ClientReservations() {
   const [status, setStatus] = useState<string>('');
-  const [renderCount, setRenderCount] = useState(INITIAL_RENDER_COUNT);
-  const [displayReservations, setDisplayReservations] = useState<Reservation[]>([]);
 
   const selectedLabel = useMemo(() => {
     return filterOptions.find(option => option.value === status)?.label || '전체';
@@ -30,7 +26,6 @@ export default function ClientReservations() {
     const statusValue = selectedOption ? selectedOption.value : '';
     setStatus(statusValue);
   };
-
   // 커서 기반 무한 스크롤 예약 데이터 불러오기
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } = useInfiniteQuery({
     queryKey: ['myReservations', status],
@@ -44,37 +39,15 @@ export default function ClientReservations() {
     initialPageParam: undefined,
   });
 
-  // memo로 모든 예약 데이터 최적화
-  const allReservations = useMemo(() => {
-    return Array.isArray(data?.pages) ? data.pages.flatMap(page => page.reservations ?? []) : [];
-  }, [data]);
-
-  // renderCount만큼 예약 데이터를 보여줄 상태 관리
-  useEffect(() => {
-    const newReservations = allReservations.slice(0, renderCount);
-    setDisplayReservations(newReservations);
-  }, [allReservations, renderCount]);
-
-  useEffect(() => {
-    setRenderCount(INITIAL_RENDER_COUNT);
-  }, [status, data]);
-
-  // IntersectionObserver로 무한스크롤
   const observerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!observerRef.current) {
-      return () => {};
-    }
+    if (!observerRef.current) return () => {};
 
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting) {
-          if (renderCount < allReservations.length) {
-            setRenderCount(prev => Math.min(prev + INITIAL_RENDER_COUNT, allReservations.length));
-          } else if (hasNextPage && !isFetchingNextPage) {
-            fetchNextPage();
-          }
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
         }
       },
       { rootMargin: '100px' },
@@ -82,10 +55,11 @@ export default function ClientReservations() {
 
     observer.observe(observerRef.current);
 
-    return () => {
-      observer.disconnect();
-    };
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage, renderCount, allReservations.length]);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  // 모든 예약 데이터 펼치기
+  const allReservations = data?.pages.flatMap(page => page.reservations ?? []) ?? [];
 
   return (
     <div className="mb-6 ml-6">
@@ -119,12 +93,20 @@ export default function ClientReservations() {
         <EmptyState />
       ) : (
         <div className="flex flex-col gap-6 mb-40">
-          {displayReservations.map(reservation => (
-            <ReservationCard key={reservation.id} reservation={reservation} />
-          ))}
+          {data?.pages.map(page =>
+            page.reservations.map(reservation => <ReservationCard key={reservation.id} reservation={reservation} />),
+          )}
 
           <div ref={observerRef} style={{ height: 1 }} />
-          {isFetchingNextPage && <div>로딩 중...</div>}
+
+          {/* 로딩 중 스켈레톤 */}
+          {isFetchingNextPage && (
+            <div className="flex flex-col gap-4">
+              {Array.from({ length: 1 }).map((_, idx) => (
+                <SkeletonCard key={idx} />
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/components/domain/reservation/ClientReservations.tsx
+++ b/components/domain/reservation/ClientReservations.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useEffect, useRef } from 'react';
+import { useState, useRef } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import Image from 'next/image';
 
@@ -11,21 +11,20 @@ import DropdownMenu from '@/components/common/DropDown';
 
 import { filterOptions } from '@/constants/filterOption';
 import { getMyReservations } from '@/services/myReservations';
+import useObserver from '@/hooks/useObserver';
 
 const PAGE_SIZE = 10;
 
 export default function ClientReservations() {
   const [status, setStatus] = useState<string>('');
 
-  const selectedLabel = useMemo(() => {
-    return filterOptions.find(option => option.value === status)?.label || '전체';
-  }, [status]);
+  const selectedLabel = filterOptions.find(option => option.value === status)?.label || '전체';
 
   const handleSelectStatus = (label: string) => {
     const selectedOption = filterOptions.find(option => option.label === label);
-    const statusValue = selectedOption ? selectedOption.value : '';
-    setStatus(statusValue);
+    setStatus(selectedOption ? selectedOption.value : '');
   };
+
   // 커서 기반 무한 스크롤 예약 데이터 불러오기
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } = useInfiniteQuery({
     queryKey: ['myReservations', status],
@@ -41,74 +40,74 @@ export default function ClientReservations() {
 
   const observerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!observerRef.current) return () => {};
+  useObserver(
+    observerRef,
+    () => {
+      if (hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
+    },
+    { rootMargin: '100px' },
+  );
 
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
-          fetchNextPage();
-        }
-      },
-      { rootMargin: '100px' },
-    );
-
-    observer.observe(observerRef.current);
-
-    return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
-
-  // 모든 예약 데이터 펼치기
   const allReservations = data?.pages.flatMap(page => page.reservations ?? []) ?? [];
 
-  return (
-    <div className="mb-6 ml-6">
-      <div className="flex items-center justify-between mb-4 max-w-full md:max-w-[600px] lg:max-w-[792px]">
-        <h1 className="text-3xl-bold mb-2">예약 내역</h1>
-        <DropdownMenu
-          options={filterOptions.map(option => option.label)}
-          onSelect={handleSelectStatus}
-          trigger={
-            <button className="w-[158px] h-[53px] rounded-[15px] border border-green-500 bg-white flex items-center justify-between px-4 mb-2">
-              <span className="text-green-500 text-2lg-medium">{selectedLabel}</span>
-              <Image src="/ic_vector.svg" alt="드롭다운 아이콘" width={16} height={16} />
-            </button>
-          }
-        >
-          {option => (
-            <span className="flex justify-center items-center w-full text-center mb-2 last:mb-0">{option}</span>
-          )}
-        </DropdownMenu>
-      </div>
-
-      {isLoading ? (
+  const renderContent = () => {
+    if (isLoading) {
+      return (
         <div className="flex flex-col gap-6 mb-40">
           {Array.from({ length: 5 }).map((_, idx) => (
             <SkeletonCard key={idx} />
           ))}
         </div>
-      ) : isError ? (
-        <div className="text-red-500 text-lg mt-4">예약 내역을 불러오는 데 실패했습니다.</div>
-      ) : allReservations.length === 0 ? (
-        <EmptyState />
-      ) : (
-        <div className="flex flex-col gap-6 mb-40">
-          {data?.pages.map(page =>
-            page.reservations.map(reservation => <ReservationCard key={reservation.id} reservation={reservation} />),
-          )}
+      );
+    }
 
-          <div ref={observerRef} style={{ height: 1 }} />
+    if (isError) {
+      return <div className="text-red-500 text-lg mt-4">예약 내역을 불러오는 데 실패했습니다.</div>;
+    }
 
-          {/* 로딩 중 스켈레톤 */}
-          {isFetchingNextPage && (
-            <div className="flex flex-col gap-4">
-              {Array.from({ length: 1 }).map((_, idx) => (
-                <SkeletonCard key={idx} />
-              ))}
-            </div>
+    if (allReservations.length === 0) {
+      return <EmptyState />;
+    }
+
+    return (
+      <div className="flex flex-col gap-6 mb-40">
+        {allReservations.map(reservation => (
+          <ReservationCard key={reservation.id} reservation={reservation} />
+        ))}
+        <div ref={observerRef} style={{ height: 1 }} />
+        {isFetchingNextPage && (
+          <div className="flex flex-col gap-4">
+            <SkeletonCard />
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="mb-6 ml-6">
+      <div className="flex items-center justify-between mb-4 max-w-full md:max-w-[600px] lg:max-w-[792px]">
+        <h1 className="text-xl-bold md:text-2xl-bold lg:text-3xl-bold mb-2">예약 내역</h1>
+        <DropdownMenu
+          options={filterOptions.map(option => option.label)}
+          onSelect={handleSelectStatus}
+          trigger={
+            <button className="w-[140px]  md:w-[158px]  lg:w-[158px] h-[53px] rounded-[15px] border border-green-500 bg-white flex items-center justify-between px-3 md:px-4 mb-2">
+              <span className="text-green-500 text-lg-bold md:text-lg-bold lg:text-2lg-bold">{selectedLabel}</span>
+              <Image src="/ic_vector.svg" alt="드롭다운 아이콘" width={16} height={16} />
+            </button>
+          }
+        >
+          {option => (
+            <span className="flex justify-center items-center w-full text-center !text-[14px] md:!text-lg-medium mb-2 last:mb-0">
+              {option}
+            </span>
           )}
-        </div>
-      )}
+        </DropdownMenu>
+      </div>
+      {renderContent()}
     </div>
   );
 }

--- a/components/domain/reservation/ReservationCard.tsx
+++ b/components/domain/reservation/ReservationCard.tsx
@@ -25,7 +25,7 @@ export default function ReservationCard({ reservation }: { reservation: Reservat
       rightButtonText: '취소하기',
       onConfirm: async ({ closeModal }: { closeModal: () => void }) => {
         try {
-          await patchMyReservations(reservation.id, { status: 'canceled' });
+          await patchMyReservations({ reservationId: reservation.id, body: { status: 'canceled' } });
           console.log('예약 취소 성공');
 
           await queryClient.invalidateQueries({ queryKey: ['myReservations'] });
@@ -99,7 +99,7 @@ export default function ReservationCard({ reservation }: { reservation: Reservat
             </CommonButton>
           )}
 
-          {reservation.status === 'declined' && (
+          {reservation.status === 'completed' && (
             <>
               {reviewSubmitted ? (
                 <CommonButton

--- a/components/domain/reservation/ReservationCard.tsx
+++ b/components/domain/reservation/ReservationCard.tsx
@@ -59,6 +59,14 @@ export default function ReservationCard({ reservation }: { reservation: Reservat
               ? 'text-gray-800'
               : '';
 
+  // 버튼과 placeholder의 공통 클래스
+  const buttonPlaceholderClass =
+    'h-[32px] md:h-[40px] lg:h-[43px] min-w-[80px] md:min-w-[112px] lg:min-w-[144px] text-[14px] rounded-[6px]';
+
+  // 공통 버튼 클래스
+  const buttonClass =
+    '!h-[32px] md:!h-[40px] lg:!h-[43px] !min-w-[80px] md:!min-w-[112px] lg:!min-w-[144px] text-[14px] md:text-[16px] lg:text-[18px] rounded-[6px] !p-[6px] md:!p-[8px]';
+
   return (
     <div className="flex w-full max-w-full md:max-w-[600px] lg:max-w-[792px] h-[128px] md:h-[156px] lg:h-[204px] bg-white rounded-xl overflow-hidden shadow-md border border-gray-100">
       <div className="flex-shrink-0 w-[128px] md:w-[156px] lg:w-[204px] h-full relative">
@@ -71,8 +79,8 @@ export default function ReservationCard({ reservation }: { reservation: Reservat
         />
       </div>
 
-      <div className="flex flex-col justify-center p-4 flex-1 min-w-0">
-        <p className={`text-lg-bold leading-tight mb-1 ${statusTextColorClass}`}>{statusInfo.text}</p>
+      <div className="flex flex-col justify-center p-2 flex-1 min-w-0">
+        <p className={`text-md-bold md:text-lg-bold leading-tight mb-1 ${statusTextColorClass}`}>{statusInfo.text}</p>
 
         <h2 className="text-black font-semibold truncate whitespace-nowrap overflow-hidden leading-tight text-md-bold md:text-lg-bold lg:text-xl-bold mb-1 lg:mb-4">
           {reservation.activity.title}
@@ -84,17 +92,12 @@ export default function ReservationCard({ reservation }: { reservation: Reservat
         </p>
 
         <div className="flex items-center justify-between mt-0 md:mt-2 lg:mt-4">
-          <p className="text-lg-bold md:text-xl-bold lg:text-2xl-bold text-black">
+          <p className="text-lg-bold mt-2 md:text-xl-bold lg:text-2xl-bold text-black">
             ₩{reservation.totalPrice.toLocaleString()}원
           </p>
 
           {reservation.status === 'pending' && (
-            <CommonButton
-              size="S"
-              variant="secondary"
-              onClick={handleCancelReservation}
-              className="h-[32px] md:h-[40px] lg:h-[43px] min-w-[80px] md:min-w-[112px] lg:min-w-[144px] rounded-[6px]"
-            >
+            <CommonButton size="S" variant="secondary" onClick={handleCancelReservation} className={buttonClass}>
               예약 취소
             </CommonButton>
           )}
@@ -106,7 +109,7 @@ export default function ReservationCard({ reservation }: { reservation: Reservat
                   size="S"
                   variant="secondary"
                   disabled
-                  className="h-[32px] md:h-[40px] lg:h-[43px] min-w-[80px] md:min-w-[112px] lg:min-w-[144px] rounded-[6px] bg-gray-300 text-gray-500 cursor-not-allowed"
+                  className={`${buttonClass} bg-gray-300 text-gray-500 cursor-not-allowed`}
                 >
                   작성 완료
                 </CommonButton>
@@ -122,16 +125,19 @@ export default function ReservationCard({ reservation }: { reservation: Reservat
                         const { closeModal } = useModalStore.getState();
                         closeModal();
                       },
-
                       onReviewSubmit: () => setReviewSubmitted(true),
                     })
                   }
-                  className="h-[32px] md:h-[40px] lg:h-[43px] min-w-[80px] md:min-w-[112px] lg:min-w-[144px] rounded-[6px]"
+                  className={buttonClass}
                 >
                   후기 작성
                 </CommonButton>
               )}
             </>
+          )}
+
+          {reservation.status !== 'pending' && reservation.status !== 'completed' && (
+            <div className={buttonPlaceholderClass} />
           )}
         </div>
       </div>

--- a/components/domain/reservation/ReviewForm.tsx
+++ b/components/domain/reservation/ReviewForm.tsx
@@ -28,7 +28,7 @@ export default function ReviewForm({
 
     setIsSubmitting(true);
     try {
-      await postMyReservations(reservation.id, { rating, content: reviewText });
+      await postMyReservations({ reservationId: reservation.id, body: { rating, content: reviewText } });
       console.log('후기 작성 완료');
 
       onReviewSubmit?.();

--- a/hooks/useObserver.ts
+++ b/hooks/useObserver.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+type UseObserverOptions = IntersectionObserverInit;
+
+export default function useObserver(
+  targetRef: React.RefObject<HTMLElement>,
+  onIntersect: () => void,
+  options?: UseObserverOptions,
+) {
+  useEffect(() => {
+    if (!targetRef.current) {
+      return undefined; // consistent-return 규칙에 맞게 undefined 반환
+    }
+
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        onIntersect();
+      }
+    }, options);
+
+    observer.observe(targetRef.current);
+
+    return () => observer.disconnect();
+  }, [targetRef, onIntersect, options]);
+}


### PR DESCRIPTION
## ✨ PR 개요
1. 기존에 있던 queryFn을 accessToken이 추가되면서 queryFn의 정확한 값으로 변경
2. 무한 스크롤에서 renderCount로 slice해서 보여준 데이터를 지우고, data.pages.map으로 데이터를 순차적으로 렌더링하여 깜빡임 제거함.
3. 드롭다운/버튼 반응형 스타일 개선
4.  useObserver 훅: IntersectionObserver를 useObserver 훅으로 분리, 관찰 로직을 재사용 가능하게 정리
5. useMemo 제거: 단순 연산이라 useMemo 대신 변수 선언으로 최적화
## 🧩 PR 요약

- [ ] 새로운 기능 추가
- [x] 버그 수정

## 🎯 작업 내용 상세 (요구사항 확인)

- [x] 드롭다운 목록 스타일 변경 (가운데 정렬, 필터 버튼과 간격)
- [x] refactor: 예약 관련 API 호출(queryFn, patch, post) 로직 수정함
- [x] 무한 스크롤 버벅거림이나 깜빡임 제거
- [x] 스켈레톤 UI: 첫 페이지 로딩은 5개를 보여주고, 이후 무한 스크롤 로딩 때는 최소 1개만 렌더링하여 버벅거림 지움
 
## 📸 스크린샷 (선택)
### pc
![image](https://github.com/user-attachments/assets/62dfb994-b64c-4aaf-a5a2-382e7e7b619a)

### 태블릿
![image](https://github.com/user-attachments/assets/d2fef692-c35b-48bc-9d0c-084ceafb86c0)

### 모바일
![image](https://github.com/user-attachments/assets/437be4c5-99e3-4dc4-bf61-b9877038431e)


## 🔗 관련 이슈 (선택)

> ex) #123 - 모달 UI 문제 이슈

## 💬 기타 전달 사항 (선택)

> 고민 중인 포인트나 논의가 필요한 부분이 있다면 작성해주세요.
예약 카드 내역 리스트를 내릴 경우 화면이 깜빡꺼림 현상 발생함.. 이후 멘토링 시간의 피드백 받은 renderCount로 slice해서 보여준 데이터를 지우고 -> 간단하게 data.pages.map으로 각 페이지 데이터를 순차적으로 렌더링(10개씩)하여 깜빡임 제거하였음.