### PR TITLE
[style] 모달 UI 수정

### DIFF
--- a/components/common/modal/OneButtonModal.tsx
+++ b/components/common/modal/OneButtonModal.tsx
@@ -1,4 +1,5 @@
 import { useModalStore } from '@/store/modalStore';
+import CommonButton from '@/components/common/CommonButton';
 
 interface OneButtonModalProps {
   content: string;
@@ -10,18 +11,23 @@ export default function OneButtonModal({ content, buttonText, onConfirm }: OneBu
   const { closeModal } = useModalStore();
 
   return (
-    <div className="bg-white rounded-2xl p-8 w-[300px] sm:w-[400px] md:w-[500px] shadow-lg">
-      <p className="text-xl-semibold text-center text-gray-900 mb-6">{content}</p>
-      <div className="flex justify-center">
-        <button
+    <div className="w-[87vw] p-[28px] bg-white rounded-lg shadow-lg md:w-[540px]">
+      <div className="h-[66px] my-[25px] md:my-[40px] flex justify-center items-center">
+        <p className="max-h-[100%] text-2lg-medium text-nomad-gray overflow-auto">{content}</p>
+      </div>
+      <div className="text-center md:text-right">
+        <CommonButton
+          size="M"
+          type="submit"
+          width="w-[138px]"
           onClick={() => {
             if (onConfirm) onConfirm();
             closeModal();
           }}
-          className="bg-nomad-black text-white text-md-medium rounded-xl px-6 py-3 w-32"
+          className="p-[9px] text-md-medium h-[42px] md:w-[120px] md:h-[48px]"
         >
           {buttonText || '확인'}
-        </button>
+        </CommonButton>
       </div>
     </div>
   );

--- a/components/common/modal/TwoButtonModal.tsx
+++ b/components/common/modal/TwoButtonModal.tsx
@@ -1,5 +1,8 @@
 'use client';
+import Image from 'next/image';
 import { useModalStore } from '@/store/modalStore';
+import CommonButton from '@/components/common/CommonButton';
+import ModalIconSrc from '@/public/ic_modal_check.svg';
 
 interface ModalProps {
   content: string;
@@ -13,26 +16,36 @@ export default function TwoButtonModal({ content, rightButtonText, leftButtonTex
   const { closeModal } = useModalStore();
 
   return (
-    <div className="bg-white rounded-2xl p-8 w-[300px] sm:w-[400px] md:w-[500px] shadow-lg">
-      <p className="text-xl-semibold text-center text-gray-900 mb-6">{content}</p>
-      <div className="flex justify-between gap-4">
-        <button
+    <div className="relative w-[298px] p-[24px] bg-white rounded-lg shadow-lg">
+      <div className="absolute w-6 h-6 top-6 left-0 right-0 mx-auto">
+        <Image src={ModalIconSrc} width={24} height={24} alt="" />
+      </div>
+      <div className="mt-[40px] mb-[32px] flex justify-center items-center">
+        <p className="max-h-[62px] text-2lg-medium text-nomad-gray overflow-auto">{content}</p>
+      </div>
+      <div className="flex justify-center gap-2">
+        <CommonButton
+          size="S"
+          type="submit"
+          width="w-[80px]"
+          variant="secondary"
           onClick={() => {
             onCancel();
             closeModal();
           }}
-          className="bg-gray-300 text-black text-md-medium rounded-xl px-6 py-3 w-32"
         >
           {leftButtonText ? leftButtonText : '취소'}
-        </button>
-        <button
+        </CommonButton>
+        <CommonButton
+          size="S"
+          type="submit"
+          width="w-[80px]"
           onClick={() => {
             onConfirm?.({ closeModal });
           }}
-          className="bg-nomad-black text-white text-md-medium rounded-xl px-6 py-3 w-32"
         >
           {rightButtonText ? rightButtonText : '확인'}
-        </button>
+        </CommonButton>
       </div>
     </div>
   );

--- a/public/ic_modal_check.svg
+++ b/public/ic_modal_check.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="12" fill="#112211"/>
+<path d="M7.60693 12.3491L10.6873 15.5L16.2498 8.35718" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,7 @@ const config: Config = {
         black: '#1B1B1B', // 일반 블랙
         nomad: {
           black: '#112211', // 노마드 전용 포인트 브랙
+          gray: '#333236',
         },
         gray: {
           900: '#4B4B4B',
@@ -102,9 +103,7 @@ const config: Config = {
     },
   },
 
-
   plugins: [scrollbarHide],
-
 };
 
 export default config;


### PR DESCRIPTION
## ✨ PR 개요

> 모달 UI 수정

## 🧩 PR 요약

- [] 새로운 기능 추가
- [] 버그 수정
- [x] 스타일 수정

## 🎯 작업 내용 상세 (요구사항 확인)

- [x] OneButtonModal 스타일 수정
- [x] TwoButtonModal 스타일 수정

## 📸 스크린샷 (선택)
| 기능      | 스크린샷              |
| --------- | --------------------- |
| oneButton모달 pc | ![image](https://github.com/user-attachments/assets/277fc1fb-6764-4cca-aeaf-55ac8f525c60) |
| oneButton모달  mo | ![image](https://github.com/user-attachments/assets/6d2a39a1-1b6d-48df-877f-829570f53eeb) |
| twoButton모달 pc, mo| ![image](https://github.com/user-attachments/assets/b02db934-0f98-492e-8c61-f4d35295a0d2) |

## 🔗 관련 이슈 (선택)

> [#123](https://github.com/CIrcle0616/global_nomad/issues/74)  - 모달 UI 수정 이슈

## 💬 기타 전달 사항 (선택)

> oneButton모달 폰트 색이 tailwind.config.ts에 등록되지 않은 색입니다. 
매번 색상값으로 지정해야해서 tailwind.config.ts 에 새로운 색 등록하였습니다. 

> oneButton모달사이즈 
  - pc : 540px
  - mo : 화면의 87% (모바일 모달 사이즈 : 327px, 그대로 사용하기는 커서 비율로 화면에 맞춤)
> twoButton 모달 사이즈 : pc, mo : 298px
