### PR TITLE
[Feat] 체험 상세 페이지네이션 구현

### DIFF
--- a/app/activities/[activityId]/page.tsx
+++ b/app/activities/[activityId]/page.tsx
@@ -12,7 +12,7 @@ export default async function ActivityDetailPage({ params }: { params: Promise<{
   const data = await getActivitiesId(Number(activityId));
 
   return (
-    <div className="w-[375px] md:w-[696px] lg:w-[1200px] mx-auto">
+    <div className="w-[375px] md:w-[696px] lg:w-[1200px] mx-auto mb-[133px] md:mb-[145px] lg:mb-[293px]">
       <ActivityDetailInfo data={data} />
       <div className="md:flex md:w-full">
         <div>

--- a/app/activities/[activityId]/page.tsx
+++ b/app/activities/[activityId]/page.tsx
@@ -2,6 +2,7 @@ import ActivityDetailInfo from '@/components/domain/activityDetail/ActivityDetai
 import ActivityDetailReview from '@/components/domain/activityDetail/ActivityDetailReview';
 import ActivityMap from '@/components/domain/activityDetail/ActivityMap';
 import ActivityDescription from '@/components/domain/activityDetail/ActivityDescription';
+import ReservationSection from './ReservationSection';
 import { getActivitiesId } from '@/services/activities';
 import React from 'react';
 
@@ -19,7 +20,9 @@ export default async function ActivityDetailPage({ params }: { params: Promise<{
           <ActivityMap address={data.address} />
           <ActivityDetailReview activityId={Number(activityId)} />
         </div>
-        <div className="md:w-[251px] lg:w-[384px]">floating-box</div>
+        <div className="md:w-[251px] lg:w-[384px]">
+          <ReservationSection />
+        </div>
       </div>
     </div>
   );

--- a/components/domain/activityDetail/ActivityDetailReview.tsx
+++ b/components/domain/activityDetail/ActivityDetailReview.tsx
@@ -1,17 +1,30 @@
 'use client';
+
 import ReviewHeader from './ReviewHeader';
 import { useQuery } from '@tanstack/react-query';
 import { getReviews } from '@/services/activities';
 import ReviewList from './ReviewList';
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
+import ReviewPagination from './ReviewPagination';
 
 export default function ActivityDetailReview({ activityId }: { activityId: number }) {
+  const [filter, setFilter] = useState<'최신 순' | '별점 높은 순' | '별점 낮은 순'>('최신 순');
+  const [currentPage, setCurrentPage] = useState(1);
+  const reviewsPerPage = 3;
+
   const { data, isPending, isError } = useQuery({
     queryKey: ['activityReview', activityId],
-    queryFn: () => getReviews({ activityId, size: 1000 }),
+    queryFn: () =>
+      getReviews({
+        activityId,
+        size: 1000, // 백엔드에서 sort기능 지원 x => 충분한 양의 리뷰 가져오기
+      }),
   });
 
-  const [filter, setFilter] = useState<'최신 순' | '별점 높은 순' | '별점 낮은 순'>('최신 순');
+  // 필터 바뀌면 첫 페이지로 이동
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [filter]);
 
   const sortedReviews = useMemo(() => {
     if (!data?.reviews) return [];
@@ -27,17 +40,22 @@ export default function ActivityDetailReview({ activityId }: { activityId: numbe
     return reviewsCopy.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
   }, [data?.reviews, filter]);
 
-  if (isPending) {
-    return <div>Loading...</div>;
-  }
-  if (isError) {
-    return <div>Error loading data</div>;
-  }
+  const startIndex = (currentPage - 1) * reviewsPerPage;
+  const currentReviews = sortedReviews.slice(startIndex, startIndex + reviewsPerPage);
+
+  if (isPending) return <div>Loading...</div>;
+  if (isError) return <div>Error loading data</div>;
+
   return (
     <div className="w-[327px] mt-10 md:w-[469px] md:mt-0 lg:w-[800px] mx-auto">
-      <div className="border-t border-gray-400 my-4 md:my-10 md:w-[469px] lg:w-[790px]"></div>
+      <div className="border-t border-gray-400 my-4 md:my-10 md:w-[469px] lg:w-[790px]" />
       <ReviewHeader data={data} filter={filter} setFilter={setFilter} />
-      <ReviewList reviews={sortedReviews} />
+      <ReviewList reviews={currentReviews} />
+      <ReviewPagination
+        totalCount={sortedReviews.length}
+        currentPage={currentPage}
+        onPageChange={page => setCurrentPage(page)}
+      />
     </div>
   );
 }

--- a/components/domain/activityDetail/ReviewPagination.tsx
+++ b/components/domain/activityDetail/ReviewPagination.tsx
@@ -9,9 +9,24 @@ export default function ReviewPagination({
 }) {
   const reviewsPerPage = 3;
   const totalPage = Math.ceil(totalCount / reviewsPerPage);
+  const isFirstPage = currentPage === 1;
+  const isLastPage = currentPage === totalPage;
 
   return (
     <div className="flex items-center justify-center gap-2.5 w-full mt-4">
+      {/* 왼쪽 화살표 */}
+      <button
+        onClick={() => !isFirstPage && onPageChange(currentPage - 1)}
+        disabled={isFirstPage}
+        className={`size-[40px] md:size-[55px] flex items-center justify-center rounded-2xl border text-sm ${
+          isFirstPage
+            ? 'border-gray-300 text-gray-300 cursor-not-allowed'
+            : 'border-green-500 text-green-500 hover:bg-green-500 hover:text-white'
+        }`}
+      >
+        ◀
+      </button>
+      {/* 페이지 번호 */}
       {Array.from({ length: totalPage }, (_, index) => {
         const pageNumber = index + 1;
         const isActive = pageNumber === currentPage;
@@ -28,6 +43,18 @@ export default function ReviewPagination({
           </button>
         );
       })}
+      {/* 오른쪽 화살표 */}
+      <button
+        onClick={() => !isLastPage && onPageChange(currentPage + 1)}
+        disabled={isLastPage}
+        className={`size-[40px] md:size-[55px] flex  items-center justify-center rounded-2xl border text-sm pl-1 ${
+          isLastPage
+            ? 'border-gray-300 text-gray-300 cursor-not-allowed'
+            : 'border-green-500 text-green-500 hover:bg-green-500 hover:text-white'
+        }`}
+      >
+        ▶
+      </button>
     </div>
   );
 }

--- a/components/domain/activityDetail/ReviewPagination.tsx
+++ b/components/domain/activityDetail/ReviewPagination.tsx
@@ -1,0 +1,33 @@
+export default function ReviewPagination({
+  totalCount,
+  currentPage,
+  onPageChange,
+}: {
+  totalCount: number;
+  currentPage: number;
+  onPageChange: (page: number) => void;
+}) {
+  const reviewsPerPage = 3;
+  const totalPage = Math.ceil(totalCount / reviewsPerPage);
+
+  return (
+    <div className="flex items-center justify-center gap-2.5 w-full mt-4">
+      {Array.from({ length: totalPage }, (_, index) => {
+        const pageNumber = index + 1;
+        const isActive = pageNumber === currentPage;
+
+        return (
+          <button
+            key={pageNumber}
+            onClick={() => onPageChange(pageNumber)}
+            className={`size-[40px] md:size-[55px] px-[14.52px] py-[7px] md:px-[22px] md:py-[14.5px] rounded-2xl border ${
+              isActive ? 'bg-green-500 text-white border-green-500' : 'border-green-500'
+            }`}
+          >
+            {pageNumber}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## ✨ PR 개요

> 검색 컴포넌트 생성 및 반응형 구현

## 🧩 PR 요약

- [x] 새로운 기능 추가
- [ ] 버그 수정

## 🎯 작업 내용 상세 (요구사항 확인)

- [x] 정렬 필터 변경 시 첫 페이지로 자동 이동
- [x] 리뷰 3개씩 페이지네이션 기능 구현
- [x] 예약 섹션 컴포넌트(ReservationSection) 상세 페이지에 추가
- [x] 페이지네이션 좌우 화살표 버튼 추가
- [x] 첫 페이지/마지막 페이지일 경우 비활성화 처리

## 📸 스크린샷 (선택)

> UI 변경이 있는 경우 추가

| 기능      | 스크린샷              |
| --------- | --------------------- |
| 팀생성 폼 | ![image](https://github.com/user-attachments/assets/d833ed1e-e2f4-4b16-9d86-324112e12c72) |

## 🔗 관련 이슈 (선택)

> ex) #85 체험 상세 후기 페이지네이션

## 💬 기타 전달 사항 (선택)

> 
