### PR TITLE
[Refactor,Feat] 내정보, 프로필 이미지 업로드 수정 사항 반영

### DIFF
--- a/app/profile/info/page.tsx
+++ b/app/profile/info/page.tsx
@@ -1,5 +1,18 @@
+import { HydrationBoundary, QueryClient, dehydrate } from '@tanstack/react-query';
+import { getUserMe } from '@/services/users';
 import MyInfoForm from '@/components/domain/profile/MyInfoForm';
 
-export default function MyInfoPage() {
-  return <MyInfoForm />;
+export default async function MyInfoPage() {
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery({
+    queryKey: ['myInfo'],
+    queryFn: () => getUserMe(),
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <MyInfoForm />;
+    </HydrationBoundary>
+  );
 }

--- a/app/profile/layout.tsx
+++ b/app/profile/layout.tsx
@@ -1,5 +1,18 @@
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
 import ProfileLayout from '@/components/layout/ProfileLayout';
+import { getUserMe } from '@/services/users';
 
-export default function ProfileSectionLayout({ children }: { children: React.ReactNode }) {
-  return <ProfileLayout>{children}</ProfileLayout>;
+export default async function ProfileSectionLayout({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery({
+    queryKey: ['myInfo'],
+    queryFn: () => getUserMe(),
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ProfileLayout>{children}</ProfileLayout>
+    </HydrationBoundary>
+  );
 }

--- a/components/common/ProfileImageUploader.tsx
+++ b/components/common/ProfileImageUploader.tsx
@@ -15,14 +15,11 @@ export default function ProfileImageUploader({ onFileSelected }: ProfileImageUpl
 
   const { data: myInfoData } = useQuery({
     queryKey: ['myInfo'],
-    queryFn: () => {
-      return getUserMe();
-    },
+    queryFn: () => getUserMe(),
   });
 
   useEffect(() => {
-    if (!myInfoData) return;
-    if (myInfoData.profileImageUrl) {
+    if (myInfoData?.profileImageUrl) {
       setProfileUrl(myInfoData.profileImageUrl);
     }
   }, [myInfoData]);

--- a/components/domain/profile/MyInfoForm.tsx
+++ b/components/domain/profile/MyInfoForm.tsx
@@ -15,6 +15,7 @@ import OneButtonModal from '@/components/common/modal/OneButtonModal';
 import { useProfileImageUpload } from '@/hooks/useProfileImageUpload';
 
 type userInfoInputs = UpdateUserBodyDto & {
+  email: string;
   passwordConfirm: string;
 };
 
@@ -26,11 +27,15 @@ export default function MyInfoPage() {
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
-  const { data, isSuccess, isError, error } = useQuery({
+  const {
+    data: myInfoData,
+    isLoading,
+    isSuccess,
+    isError,
+    error,
+  } = useQuery({
     queryKey: ['myInfo'],
-    queryFn: () => {
-      return getUserMe();
-    },
+    queryFn: () => getUserMe(),
   });
 
   const {
@@ -74,15 +79,15 @@ export default function MyInfoPage() {
   };
 
   useEffect(() => {
-    if (isSuccess && data) {
+    if (isSuccess && myInfoData) {
       reset({
-        nickname: data.nickname,
+        nickname: myInfoData.nickname,
         newPassword: '',
         passwordConfirm: '',
       });
-      setEmail(data.email);
+      setEmail(myInfoData.email);
     }
-  }, [data, isSuccess, reset]);
+  }, [myInfoData, isSuccess, reset]);
 
   if (isError) {
     console.error('에러 내용:', error);
@@ -102,6 +107,14 @@ export default function MyInfoPage() {
       });
     },
   );
+
+  if (isLoading) {
+    return <p className="text-center text-gray-500">로딩 중입니다...</p>;
+  }
+
+  if (isError || !myInfoData) {
+    return <p className="text-center text-red-500">새로고침 해주세요.</p>;
+  }
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>

--- a/components/domain/profile/MyInfoForm.tsx
+++ b/components/domain/profile/MyInfoForm.tsx
@@ -9,6 +9,7 @@ import { UpdateUserBodyDto } from '@/types';
 import { GetMyInfoSuccessResponse } from '@/types/domain/user/types';
 import { useModalStore } from '@/store/modalStore';
 import Input from '@/components/common/Input';
+import SkeletonMyInfoForm from '@/components/skeleton/SkeletonMyInfoForm';
 import CommonButton from '@/components/common/CommonButton';
 import ProfileImageUploader from '@/components/common/ProfileImageUploader';
 import OneButtonModal from '@/components/common/modal/OneButtonModal';
@@ -109,7 +110,7 @@ export default function MyInfoPage() {
   );
 
   if (isLoading) {
-    return <p className="text-center text-gray-500">로딩 중입니다...</p>;
+    return <SkeletonMyInfoForm />;
   }
 
   if (isError || !myInfoData) {

--- a/components/skeleton/SkeletonMyInfoForm.tsx
+++ b/components/skeleton/SkeletonMyInfoForm.tsx
@@ -1,0 +1,34 @@
+export default function SkeletonMyInfoForm() {
+  return (
+    <div className="px-6 mb-[120px] animate-pulse">
+      <div className="flex justify-between items-center">
+        <div className="w-36 h-10 bg-gray-300 rounded" />
+        <div className="w-[120px] h-12  bg-gray-300 rounded" />
+      </div>
+
+      <section className="space-y-6">
+        <div className="md:hidden w-[160px] h-[160px] bg-gray-200 rounded-full mx-auto" />
+
+        <div className="space-y-5">
+          <div className="w-28 h-8 bg-gray-300 rounded" />
+          <div className="h-12 bg-gray-200 rounded" />
+        </div>
+
+        <div className="space-y-5">
+          <div className="w-28 h-8 bg-gray-300 rounded" />
+          <div className="h-12 bg-gray-200 rounded" />
+        </div>
+
+        <div className="space-y-5">
+          <div className="w-28 h-8 bg-gray-300 rounded" />
+          <div className="h-12 bg-gray-200 rounded" />
+        </div>
+
+        <div className="space-y-5">
+          <div className="w-40 h-8 bg-gray-300 rounded" />
+          <div className="h-12 bg-gray-200 rounded" />
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## ✨ PR 개요

> 내 정보, 이미지 업로드 컴포넌트 서버 데이터 패칭으로 수정

## 🧩 PR 요약

- [x] 새로운 기능 추가
- [ ] 버그 수정

## 🎯 작업 내용 상세 (요구사항 확인)

- [x] 클라이언트 데이터 패칭을 서버에서 데이터패칭하는 것으로 수정 함 
- [ ] 내정보 영역 로딩 중 스켈레톤 UI 적용 


## 📸 스크린샷 (선택)

> UI 변경이 있는 경우 추가

| 기능      | 스크린샷              |
| --------- | --------------------- |
| 수정 전 |  ![수정전](https://github.com/user-attachments/assets/6b71887b-34ee-4a77-9da7-5bbddb08e432)|
| 수정 후 | ![수정후](https://github.com/user-attachments/assets/7454489f-6175-494f-8eee-70355f6acde5) |

## 🔗 관련 이슈 (선택)

> ex) #123 - 모달 UI 문제 이슈

## 💬 기타 전달 사항 (선택)

> 고민 중인 포인트나 논의가 필요한 부분이 있다면 작성해주세요.
수정 전에는 form 영역이 생성되고 나서 데이터 패칭이 되었는데 
수정 후에는 데이터 패칭이 된 후 form 영역이 화면에 보입니다. 
그리고 로딩 중 화면에 form 영역이 보이지 않을 때 스켈레톤 UI 가 보일 수 있도록 하였습니다. 