### PR TITLE
[Refactor] 체험 상세 페이지 리팩토링, 이미지 섹션 개선, Dropdown 아이디 수정

### DIFF
--- a/app/activities/[activityId]/page.tsx
+++ b/app/activities/[activityId]/page.tsx
@@ -12,7 +12,7 @@ export default async function ActivityDetailPage({ params }: { params: Promise<{
   const data = await getActivitiesId(Number(activityId));
 
   return (
-    <div className="w-[375px] md:w-[696px] lg:w-[1200px] mx-auto mb-[133px] md:mb-[145px] lg:mb-[293px] relative">
+    <div className="w-[375px] md:w-[696px] lg:w-[1024px] mx-auto mb-[133px] md:mb-[145px] lg:mb-[293px] relative">
       <ActivityDetailInfo data={data} />
       <div className="md:flex md:w-full">
         <div>

--- a/app/activities/[activityId]/page.tsx
+++ b/app/activities/[activityId]/page.tsx
@@ -12,7 +12,7 @@ export default async function ActivityDetailPage({ params }: { params: Promise<{
   const data = await getActivitiesId(Number(activityId));
 
   return (
-    <div className="w-[375px] md:w-[696px] lg:w-[1024px] mx-auto mb-[133px] md:mb-[145px] lg:mb-[293px] relative">
+    <div className="w-[375px] md:w-[696px] lg:w-[900px] mx-auto mb-[133px] md:mb-[145px] lg:mb-[293px] relative">
       <ActivityDetailInfo data={data} />
       <div className="md:flex md:w-full">
         <div>
@@ -20,7 +20,7 @@ export default async function ActivityDetailPage({ params }: { params: Promise<{
           <ActivityMap address={data.address} />
           <ActivityDetailReview activityId={Number(activityId)} />
         </div>
-        <div className="md:w-[251px] lg:w-[384px] ml-6">
+        <div className="ml-6">
           <div
             className="
           fixed bottom-0 left-0 w-full z-10 bg-white border-t shadow-[0_-4px_10px_rgba(0,0,0,0.1)]

--- a/components/domain/activityDetail/ActivityDescription.tsx
+++ b/components/domain/activityDetail/ActivityDescription.tsx
@@ -3,12 +3,12 @@ import { GetActivityDetailSuccessResponse } from '@/types/domain/activity/types'
 export default function ActivityDescription({ data }: { data: GetActivityDetailSuccessResponse }) {
   return (
     <>
-      <div className="md:border-t md:border-gray-400 md:mb-10 md:w-[469px] lg:w-[790px]"></div>
-      <div className="w-[327px] md:w-[455px] lg:w-[790px] mx-auto mt-[15px] md:mt-6">
+      <div className="md:border-t md:border-gray-400 md:mb-10 md:w-[469px] lg:w-[614px]"></div>
+      <div className="w-[327px] md:w-[455px] lg:w-[614px] mx-auto mt-[15px] md:mt-6">
         <div className="text-xl-bold text-nomad-black mb-4">체험 설명</div>
         <div>{data.description}</div>
       </div>
-      <div className="border-t border-gray-400 my-4 md:my-10 md:w-[469px] lg:w-[790px]"></div>
+      <div className="border-t border-gray-400 my-4 md:my-10 md:w-[469px] lg:w-[614px]"></div>
     </>
   );
 }

--- a/components/domain/activityDetail/ActivityDescription.tsx
+++ b/components/domain/activityDetail/ActivityDescription.tsx
@@ -3,12 +3,12 @@ import { GetActivityDetailSuccessResponse } from '@/types/domain/activity/types'
 export default function ActivityDescription({ data }: { data: GetActivityDetailSuccessResponse }) {
   return (
     <>
-      <div className="md:border-t md:border-gray-400 md:mb-10 md:w-[469px] lg:w-[614px]"></div>
-      <div className="w-[327px] md:w-[455px] lg:w-[614px] mx-auto mt-[15px] md:mt-6">
+      <div className="md:border-t md:border-gray-400 md:mb-10 md:w-[469px] lg:w-[490px]"></div>
+      <div className="w-[327px] md:w-[455px] lg:w-[490px] mx-auto mt-[15px] md:mt-6">
         <div className="text-xl-bold text-nomad-black mb-4">체험 설명</div>
         <div>{data.description}</div>
       </div>
-      <div className="border-t border-gray-400 my-4 md:my-10 md:w-[469px] lg:w-[614px]"></div>
+      <div className="border-t border-gray-400 my-4 md:my-10 md:w-[469px] lg:w-[490px]"></div>
     </>
   );
 }

--- a/components/domain/activityDetail/ActivityDetailReview.tsx
+++ b/components/domain/activityDetail/ActivityDetailReview.tsx
@@ -47,8 +47,8 @@ export default function ActivityDetailReview({ activityId }: { activityId: numbe
   if (isError) return <div>Error loading data</div>;
 
   return (
-    <div className="w-[327px] mt-10 md:w-[469px] md:mt-0 lg:w-[624px] mx-auto">
-      <div className="md:border-t md:border-gray-400 my-4 md:my-10 md:w-[469px] lg:w-[613px]" />
+    <div className="w-[327px] mt-10 md:w-[469px] md:mt-0 lg:w-[500px] mx-auto">
+      <div className="md:border-t md:border-gray-400 my-4 md:my-10 md:w-[469px] lg:w-[489px]" />
       <ReviewHeader data={data} filter={filter} setFilter={setFilter} />
       <ReviewList reviews={currentReviews} />
       <ReviewPagination

--- a/components/domain/activityDetail/ActivityDetailReview.tsx
+++ b/components/domain/activityDetail/ActivityDetailReview.tsx
@@ -47,8 +47,8 @@ export default function ActivityDetailReview({ activityId }: { activityId: numbe
   if (isError) return <div>Error loading data</div>;
 
   return (
-    <div className="w-[327px] mt-10 md:w-[469px] md:mt-0 lg:w-[800px] mx-auto">
-      <div className="md:border-t md:border-gray-400 my-4 md:my-10 md:w-[469px] lg:w-[790px]" />
+    <div className="w-[327px] mt-10 md:w-[469px] md:mt-0 lg:w-[624px] mx-auto">
+      <div className="md:border-t md:border-gray-400 my-4 md:my-10 md:w-[469px] lg:w-[613px]" />
       <ReviewHeader data={data} filter={filter} setFilter={setFilter} />
       <ReviewList reviews={currentReviews} />
       <ReviewPagination

--- a/components/domain/activityDetail/ActivityImgSection.tsx
+++ b/components/domain/activityDetail/ActivityImgSection.tsx
@@ -1,148 +1,22 @@
 'use client';
 import { GetActivityDetailSuccessResponse } from '@/types/domain/activity/types';
-import Image from 'next/image';
-import { useEffect, useRef, useState } from 'react';
 import { useModalStore } from '@/store/modalStore';
 import ModalImageViewer from './ModalImgViewer';
+import ActivityPcImgView from './ActivityPCImgView';
+import ActivityMobileImgView from './ActivityMobileImgView';
 
 export default function ActivityImgSection({ data }: { data: GetActivityDetailSuccessResponse }) {
-  const sliderRef = useRef<HTMLDivElement>(null); // 자동 스크롤을 위한 useRef
-  const intervalRef = useRef<NodeJS.Timeout | null>(null); // 자동 스크롤 타이머
-  const [isHover, setIsHover] = useState(false);
   const { openModal } = useModalStore();
+  const allImages = [data.bannerImageUrl, ...data.subImages.map(img => img.imageUrl)];
 
-  // 이미지 자동 스크롤
-  useEffect(() => {
-    const slider = sliderRef.current;
-    if (!slider) return undefined;
-
-    // Hover 중에는 슬라이드 멈춤
-    if (isHover) {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-      return undefined;
-    }
-
-    intervalRef.current = setInterval(() => {
-      if (!slider) return;
-
-      // 현재 스크롤이 끝에 도달했는지 확인
-      const maxScrollLeft = slider.scrollWidth - slider.offsetWidth; //전체 가로길이 - 보이는 길이
-      const isAtEnd = Math.ceil(slider.scrollLeft) >= maxScrollLeft;
-
-      if (isAtEnd) {
-        // 끝까지 갔으면 처음으로 돌아가기
-        slider.scrollTo({ left: 0, behavior: 'smooth' });
-      } else {
-        // 아니라면 다음으로 스크롤
-        slider.scrollBy({ left: slider.offsetWidth, behavior: 'smooth' });
-      }
-    }, 5000);
-
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    }; //클린업
-  }, [isHover]);
-
-  //왼쪽/오른쪽 버튼 눌렀을때
-  const scrollLeft = () => {
-    if (sliderRef.current) {
-      sliderRef.current.scrollBy({ left: -sliderRef.current.offsetWidth, behavior: 'smooth' });
-    }
-  };
-
-  const scrollRight = () => {
-    if (sliderRef.current) {
-      sliderRef.current.scrollBy({ left: sliderRef.current.offsetWidth, behavior: 'smooth' });
-    }
+  const handleImageClick = (index: number) => {
+    openModal(() => <ModalImageViewer images={allImages} initialIndex={index} />);
   };
 
   return (
     <div className="w-[375px] h-[310px] md:w-[696px] lg:w-[1198px] lg:h-[534px] md:mt-4 md:mb-8 lg:mb-[85px]">
-      {/* PC, Tablet: 그리드 뷰 */}
-      <div className="hidden md:grid md:grid-cols-4 md:grid-rows-2 gap-2 w-full h-full">
-        <div
-          className="col-span-2 row-span-2 md:hover:scale-[1.02] transition-transform ease-in-out duration-500 cursor-pointer"
-          onClick={() =>
-            openModal(() => (
-              <ModalImageViewer
-                images={[data.bannerImageUrl, ...data.subImages.map(img => img.imageUrl)]}
-                initialIndex={0}
-              />
-            ))
-          }
-        >
-          <Image
-            src={data.bannerImageUrl}
-            alt="활동 대표 이미지"
-            width={1600}
-            height={900}
-            className="object-cover rounded-md"
-            style={{ width: '100%', height: '100%' }}
-          />
-        </div>
-        {data.subImages?.map((img, index) => (
-          <div
-            key={img.id}
-            className="md:hover:scale-[1.03] transition-transform ease-in-out duration-500 cursor-pointer"
-            onClick={() =>
-              openModal(() => (
-                <ModalImageViewer
-                  images={[data.bannerImageUrl, ...data.subImages.map(img => img.imageUrl)]}
-                  initialIndex={index + 1} // 서브이미지 클릭 시 1부터 시작
-                />
-              ))
-            }
-          >
-            <Image
-              src={img.imageUrl}
-              alt="활동 상세 이미지"
-              width={800}
-              height={800}
-              className="object-cover rounded-md"
-              style={{ width: '100%', height: '100%' }}
-            />
-          </div>
-        ))}
-      </div>
-
-      {/* Mobile: 슬라이드 뷰 */}
-      <div
-        className="block md:hidden relative"
-        onMouseEnter={() => setIsHover(true)}
-        onMouseLeave={() => setIsHover(false)}
-      >
-        <button
-          onClick={scrollLeft}
-          className={`absolute left-2 top-1/2 transform -translate-y-1/2 transition-opacity ${isHover ? 'opacity-100' : 'opacity-0'}`}
-        >
-          <Image src="/ic_pagination_arrow_left.svg" alt="이전" width={24} height={47} />
-        </button>
-        <button
-          onClick={scrollRight}
-          className={`absolute right-2 top-1/2 transform -translate-y-1/2 transition-opacity ${isHover ? 'opacity-100' : 'opacity-0'}`}
-        >
-          <Image src="/ic_pagination_arrow_right.svg" alt="다음" width={24} height={47} />
-        </button>
-        <div ref={sliderRef} className="overflow-x-auto whitespace-nowrap snap-x snap-mandatory scrollbar-hide">
-          <div className="inline-flex gap-2">
-            {[data.bannerImageUrl, ...data.subImages.map(img => img.imageUrl)].map((url, idx) => (
-              <div key={idx} className="flex-shrink-0 w-[375px] h-[310px] snap-center">
-                <Image
-                  src={url}
-                  alt="활동 이미지"
-                  width={1600}
-                  height={900}
-                  className="object-cover"
-                  style={{ width: '100%', height: '100%' }}
-                />
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
+      <ActivityPcImgView images={allImages} onImageClick={handleImageClick} />
+      <ActivityMobileImgView images={allImages} onImageClick={handleImageClick} />
     </div>
   );
 }

--- a/components/domain/activityDetail/ActivityImgSection.tsx
+++ b/components/domain/activityDetail/ActivityImgSection.tsx
@@ -14,7 +14,7 @@ export default function ActivityImgSection({ data }: { data: GetActivityDetailSu
   };
 
   return (
-    <div className="w-[375px] h-[310px] md:w-[696px] lg:w-[1198px] lg:h-[534px] md:mt-4 md:mb-8 lg:mb-[85px]">
+    <div className="w-[375px] h-[310px] md:w-[696px] lg:w-[1022px] lg:h-[534px] md:mt-4 md:mb-8 lg:mb-[85px]">
       <ActivityPcImgView images={allImages} onImageClick={handleImageClick} />
       <ActivityMobileImgView images={allImages} onImageClick={handleImageClick} />
     </div>

--- a/components/domain/activityDetail/ActivityImgSection.tsx
+++ b/components/domain/activityDetail/ActivityImgSection.tsx
@@ -14,7 +14,7 @@ export default function ActivityImgSection({ data }: { data: GetActivityDetailSu
   };
 
   return (
-    <div className="w-[375px] h-[310px] md:w-[696px] lg:w-[1022px] lg:h-[534px] md:mt-4 md:mb-8 lg:mb-[85px]">
+    <div className="w-[375px] h-[310px] md:w-[696px] lg:w-[900px] lg:h-[412px] md:mt-4 md:mb-8 lg:mb-[65px]">
       <ActivityPcImgView images={allImages} onImageClick={handleImageClick} />
       <ActivityMobileImgView images={allImages} onImageClick={handleImageClick} />
     </div>

--- a/components/domain/activityDetail/ActivityMap.tsx
+++ b/components/domain/activityDetail/ActivityMap.tsx
@@ -37,9 +37,9 @@ export default function ActivityMap({ address }: { address: string }) {
   if (!position) return <p>지도 위치 변환 중...</p>;
 
   return (
-    <div className="w-[327px] mx-auto md:w-[429px] lg:w-[613px] my-10">
+    <div className="w-[327px] mx-auto md:w-[429px] lg:w-[489px] my-10">
       {/* 지도 영역 */}
-      <div className="h-[450px] md:h-[276px] lg:h-[476px] relative">
+      <div className="h-[450px] md:h-[276px] lg:h-[352px] relative">
         <Map center={position} className="w-full h-full" level={3}>
           <MapMarker position={position} />
         </Map>

--- a/components/domain/activityDetail/ActivityMap.tsx
+++ b/components/domain/activityDetail/ActivityMap.tsx
@@ -37,7 +37,7 @@ export default function ActivityMap({ address }: { address: string }) {
   if (!position) return <p>지도 위치 변환 중...</p>;
 
   return (
-    <div className="w-[327px] mx-auto md:w-[429px] lg:w-[789px] my-10">
+    <div className="w-[327px] mx-auto md:w-[429px] lg:w-[613px] my-10">
       {/* 지도 영역 */}
       <div className="h-[450px] md:h-[276px] lg:h-[476px] relative">
         <Map center={position} className="w-full h-full" level={3}>

--- a/components/domain/activityDetail/ActivityMobileImgView.tsx
+++ b/components/domain/activityDetail/ActivityMobileImgView.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Image from 'next/image';
+
+interface ActivityMobileViewProps {
+  images: string[];
+  onImageClick: (index: number) => void;
+}
+
+export default function ActivityMobileView({ images, onImageClick }: ActivityMobileViewProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+
+  // 자동 슬라이드 로직
+  useEffect(() => {
+    if (isPaused) return undefined;
+
+    const interval = setInterval(() => {
+      setCurrentIndex(prevIndex => (prevIndex + 1) % images.length);
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [isPaused, images.length]);
+
+  const goToPrevious = () => {
+    setCurrentIndex(prevIndex => (prevIndex - 1 + images.length) % images.length);
+  };
+
+  const goToNext = () => {
+    setCurrentIndex(prevIndex => (prevIndex + 1) % images.length);
+  };
+
+  return (
+    <div
+      className="block md:hidden relative"
+      onMouseEnter={() => setIsPaused(true)}
+      onMouseLeave={() => setIsPaused(false)}
+    >
+      {/* 슬라이더 래퍼 (보여지는 창) */}
+      <div className="overflow-hidden w-full">
+        {/* 슬라이더 컨테이너 (움직이는 대상) */}
+        <div
+          className="flex transition-transform duration-500 ease-in-out"
+          style={{ transform: `translateX(-${currentIndex * 100}%)` }}
+        >
+          {images.map((url, idx) => (
+            <div key={idx} className="flex-shrink-0 w-full h-[310px] cursor-pointer" onClick={() => onImageClick(idx)}>
+              <Image
+                src={url}
+                alt={`활동 이미지 ${idx + 1}`}
+                width={375}
+                height={310}
+                className="w-full h-full object-cover"
+                priority={idx === 0}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* 네비게이션 버튼 */}
+      <button onClick={goToPrevious} className="absolute left-2 top-1/2 -translate-y-1/2 p-2">
+        <Image src="/ic_pagination_arrow_left.svg" alt="이전" width={24} height={47} />
+      </button>
+      <button onClick={goToNext} className="absolute right-2 top-1/2 -translate-y-1/2 p-2">
+        <Image src="/ic_pagination_arrow_right.svg" alt="다음" width={24} height={47} />
+      </button>
+    </div>
+  );
+}

--- a/components/domain/activityDetail/ActivityPCImgView.tsx
+++ b/components/domain/activityDetail/ActivityPCImgView.tsx
@@ -1,0 +1,70 @@
+import ClickableImage from '@/components/domain/activityDetail/ClickableImage';
+
+interface ActivityPcViewProps {
+  images: string[];
+  onImageClick: (index: number) => void;
+}
+
+export default function ActivityPcImgView({ images, onImageClick }: ActivityPcViewProps) {
+  if (images.length === 0) return null;
+
+  const [bannerImage, ...subImages] = images;
+  const subImageCount = subImages.length;
+
+  const renderSubImages = () => {
+    // 서브 이미지가 4개 이상이면 2x2 그리드로 고정
+    if (subImageCount >= 4) {
+      return (
+        <div className="grid grid-cols-2 gap-2 h-full">
+          {subImages.slice(0, 4).map((src, idx) => (
+            <ClickableImage
+              key={src}
+              src={src}
+              alt={`서브 이미지 ${idx + 1}`}
+              index={idx + 1}
+              onImageClick={onImageClick}
+            />
+          ))}
+        </div>
+      );
+    }
+
+    // 1, 2, 3개일 때 Flexbox로 처리
+    return (
+      <div className="flex flex-col gap-2 h-full">
+        {/* 첫 번째 서브 이미지 (1, 2, 3개일 때 모두 존재) */}
+        <div className="flex-1 min-h-0">
+          <ClickableImage src={subImages[0]} alt="서브 이미지 1" index={1} onImageClick={onImageClick} />
+        </div>
+
+        {/* 2, 3개일 때 추가되는 하단 영역 */}
+        {subImageCount > 1 && (
+          <div className="flex-1 min-h-0 flex gap-2">
+            {/* 두 번째 서브 이미지 */}
+            <div className="flex-1">
+              <ClickableImage src={subImages[1]} alt="서브 이미지 2" index={2} onImageClick={onImageClick} />
+            </div>
+            {/* 세 번째 서브 이미지 */}
+            {subImageCount > 2 && (
+              <div className="flex-1">
+                <ClickableImage src={subImages[2]} alt="서브 이미지 3" index={3} onImageClick={onImageClick} />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="hidden md:flex gap-2 w-full h-full">
+      {/* 대표 이미지 */}
+      <div className={subImageCount > 0 ? 'w-[60%]' : 'w-full'}>
+        <ClickableImage src={bannerImage} alt="대표 이미지" index={0} onImageClick={onImageClick} />
+      </div>
+
+      {/* 서브 이미지 */}
+      {subImageCount > 0 && <div className="w-[40%] h-full">{renderSubImages()}</div>}
+    </div>
+  );
+}

--- a/components/domain/activityDetail/ClickableImage.tsx
+++ b/components/domain/activityDetail/ClickableImage.tsx
@@ -1,0 +1,27 @@
+import Image from 'next/image';
+
+interface ClickableImageProps {
+  src: string;
+  alt: string;
+  index: number;
+  onImageClick: (index: number) => void;
+  className?: string;
+}
+
+/*클릭 가능한 이미지 컴포넌트.*/
+export default function ClickableImage({ src, alt, index, onImageClick, className = '' }: ClickableImageProps) {
+  return (
+    <div
+      className={`relative w-full h-full cursor-pointer overflow-hidden rounded-md group ${className}`}
+      onClick={() => onImageClick(index)}
+    >
+      <Image
+        src={src}
+        alt={alt}
+        fill
+        className="object-cover transition-transform duration-500 ease-in-out group-hover:scale-105"
+        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+      />
+    </div>
+  );
+}

--- a/components/domain/activityDetail/DropdownActivityDetail.tsx
+++ b/components/domain/activityDetail/DropdownActivityDetail.tsx
@@ -1,12 +1,11 @@
 'use client';
-import { useAuthStore } from '@/store/useAuthStore';
-import { useEffect } from 'react';
 import DropdownMenu from '@/components/common/DropDown';
 import Image from 'next/image';
 import { delMyActivities } from '@/services/myActivities';
 import { useRouter } from 'next/navigation';
 import TwoButtonModal from '@/components/common/modal/TwoButtonModal';
 import { useModalStore } from '@/store/modalStore';
+import useUserStore from '@/store/useUserStore';
 
 type DropDownActivityDetailProps = {
   userId: number;
@@ -14,24 +13,9 @@ type DropDownActivityDetailProps = {
 };
 
 export default function DropDownActivityDetail({ userId, activityId }: DropDownActivityDetailProps) {
-  const { user, setUser } = useAuthStore();
+  const { user } = useUserStore();
   const router = useRouter();
   const { openModal } = useModalStore();
-
-  useEffect(() => {
-    if (!user) {
-      const loginId = localStorage.getItem('auth-storage'); // 로컬스토리지에서 유저 정보 가져옴
-      if (loginId) {
-        try {
-          const parsed = JSON.parse(loginId);
-          const storedUser = parsed.state?.user; // 문자열을 객체로 변환하고 유저 정보만 꺼냄
-          setUser(storedUser);
-        } catch (err) {
-          console.error('auth-storage 파싱 실패:', err);
-        }
-      }
-    }
-  }, [user, setUser]);
 
   const isAuthor = user?.id === userId;
 

--- a/components/domain/activityDetail/DropdownActivityDetail.tsx
+++ b/components/domain/activityDetail/DropdownActivityDetail.tsx
@@ -42,27 +42,25 @@ export default function DropDownActivityDetail({ userId, activityId }: DropDownA
   };
 
   return (
-    <div className="mt-2 left-0 w-full min-w-[160px]">
-      <DropdownMenu
-        onSelect={value => {
-          if (value === 'edit') {
-            router.push(`/profile/activities/${activityId}/edit`);
-          } else if (value === 'delete') {
-            openDeleteModal();
-          }
-        }}
-        options={['edit', 'delete']}
-        trigger={<Image src="/ic_kebab_menu.svg" width={40} height={40} alt="케밥메뉴" />}
-      >
-        {option => {
-          if (option === 'edit') {
-            return '수정하기';
-          } else if (option === 'delete') {
-            return '삭제하기';
-          }
-          return null;
-        }}
-      </DropdownMenu>
-    </div>
+    <DropdownMenu
+      onSelect={value => {
+        if (value === 'edit') {
+          router.push(`/profile/activities/${activityId}/edit`);
+        } else if (value === 'delete') {
+          openDeleteModal();
+        }
+      }}
+      options={['edit', 'delete']}
+      trigger={<Image src="/ic_kebab_menu.svg" width={40} height={40} alt="케밥메뉴" />}
+    >
+      {option => {
+        if (option === 'edit') {
+          return '수정하기';
+        } else if (option === 'delete') {
+          return '삭제하기';
+        }
+        return null;
+      }}
+    </DropdownMenu>
   );
 }

--- a/components/domain/activityDetail/ModalImgViewer.tsx
+++ b/components/domain/activityDetail/ModalImgViewer.tsx
@@ -1,19 +1,19 @@
 'use client';
+import { useModalStore } from '@/store/modalStore';
 import Image from 'next/image';
 import { useState } from 'react';
 
 interface ModalImageViewerProps {
   images: string[];
-  initialIndex?: number; // 처음 보여질 이미지
+  initialIndex?: number;
 }
 
-// 이미지 확대 모달
 export default function ModalImageViewer({ images, initialIndex = 0 }: ModalImageViewerProps) {
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
-  const [isHover, setIsHover] = useState(false);
+  const { closeModal } = useModalStore();
 
   const prevImage = () => {
-    setCurrentIndex(prev => (prev - 1 + images.length) % images.length); //이미지 순환을 위한 로직
+    setCurrentIndex(prev => (prev - 1 + images.length) % images.length);
   };
 
   const nextImage = () => {
@@ -21,22 +21,18 @@ export default function ModalImageViewer({ images, initialIndex = 0 }: ModalImag
   };
 
   return (
-    <div
-      className="relative w-full h-full flex items-center justify-center bg-black rounded-lg"
-      onMouseEnter={() => setIsHover(true)}
-      onMouseLeave={() => setIsHover(false)}
-    >
-      <button
-        onClick={prevImage}
-        className={`absolute left-4 top-1/2 transform -translate-y-1/2 z-10 ${isHover ? 'opacity-100' : 'opacity-0'}`}
-      >
+    <div className="relative w-full h-full flex items-center justify-center bg-black rounded-lg">
+      {/* 닫기(X) 버튼 추가 */}
+      <button onClick={closeModal} className="absolute top-2 right-2 z-20 p-2">
+        <Image src="/ic_close_white.svg" alt="닫기" width={24} height={24} className="bg-gray-500 rounded-lg" />
+      </button>
+
+      {/* 이전/다음 버튼 */}
+      <button onClick={prevImage} className="absolute left-4 top-1/2 transform -translate-y-1/2 z-10">
         <Image src="/ic_pagination_arrow_left.svg" alt="이전" width={24} height={47} />
       </button>
 
-      <button
-        onClick={nextImage}
-        className={`absolute right-4 top-1/2 transform -translate-y-1/2 z-10 ${isHover ? 'opacity-100' : 'opacity-0'}`}
-      >
+      <button onClick={nextImage} className="absolute right-4 top-1/2 transform -translate-y-1/2 z-10">
         <Image src="/ic_pagination_arrow_right.svg" alt="다음" width={24} height={47} />
       </button>
 

--- a/components/domain/activityDetail/ReviewList.tsx
+++ b/components/domain/activityDetail/ReviewList.tsx
@@ -17,13 +17,12 @@ export default function ReviewList({ reviews }: { reviews: Review[] }) {
           className={`flex flex-col gap-4 py-6 ${index !== reviews.length - 1 ? 'border-b border-gray-300' : ''}`}
         >
           <div className="flex gap-4">
-            <div>
+            <div className="w-[55px] h-[55px] relative shrink-0">
               <Image
                 src={review.user.profileImageUrl || '/ic_empty.svg'}
                 alt="Profile"
-                width={60}
-                height={60}
-                className="size-full object-cover rounded-full"
+                fill
+                className="object-cover rounded-full"
               />
             </div>
             <div className="flex flex-col gap-2 w-[266px] md:w-[368px] lg:w-[792px]">

--- a/components/domain/activityDetail/ReviewPagination.tsx
+++ b/components/domain/activityDetail/ReviewPagination.tsx
@@ -1,3 +1,5 @@
+import Image from 'next/image';
+
 export default function ReviewPagination({
   totalCount,
   currentPage,
@@ -13,48 +15,63 @@ export default function ReviewPagination({
   const isLastPage = currentPage === totalPage;
 
   return (
-    <div className="flex items-center justify-center gap-2.5 w-full mt-4">
-      {/* 왼쪽 화살표 */}
-      <button
-        onClick={() => !isFirstPage && onPageChange(currentPage - 1)}
-        disabled={isFirstPage}
-        className={`size-[40px] md:size-[55px] flex items-center justify-center rounded-2xl border text-sm ${
-          isFirstPage
-            ? 'border-gray-300 text-gray-300 cursor-not-allowed'
-            : 'border-green-500 text-green-500 hover:bg-green-500 hover:text-white'
-        }`}
-      >
-        ◀
-      </button>
-      {/* 페이지 번호 */}
-      {Array.from({ length: totalPage }, (_, index) => {
-        const pageNumber = index + 1;
-        const isActive = pageNumber === currentPage;
-
-        return (
+    <>
+      {totalCount > 0 ? (
+        <div className="flex items-center justify-center gap-2.5 w-full mt-4">
+          {/* 왼쪽 화살표 */}
           <button
-            key={pageNumber}
-            onClick={() => onPageChange(pageNumber)}
-            className={`size-[40px] md:size-[55px] px-[14.52px] py-[7px] md:px-[22px] md:py-[14.5px] rounded-2xl border ${
-              isActive ? 'bg-green-500 text-white border-green-500' : 'border-green-500'
+            onClick={() => !isFirstPage && onPageChange(currentPage - 1)}
+            disabled={isFirstPage}
+            className={`size-[40px] md:size-[55px] flex items-center justify-center rounded-2xl border text-sm ${
+              isFirstPage
+                ? 'border-gray-300 text-gray-300 cursor-not-allowed'
+                : 'border-green-500 text-green-500 hover:bg-green-500 hover:text-white'
             }`}
           >
-            {pageNumber}
+            ◀
           </button>
-        );
-      })}
-      {/* 오른쪽 화살표 */}
-      <button
-        onClick={() => !isLastPage && onPageChange(currentPage + 1)}
-        disabled={isLastPage}
-        className={`size-[40px] md:size-[55px] flex  items-center justify-center rounded-2xl border text-sm pl-1 ${
-          isLastPage
-            ? 'border-gray-300 text-gray-300 cursor-not-allowed'
-            : 'border-green-500 text-green-500 hover:bg-green-500 hover:text-white'
-        }`}
-      >
-        ▶
-      </button>
-    </div>
+          {/* 페이지 번호 */}
+          {Array.from({ length: totalPage }, (_, index) => {
+            const pageNumber = index + 1;
+            const isActive = pageNumber === currentPage;
+
+            return (
+              <button
+                key={pageNumber}
+                onClick={() => onPageChange(pageNumber)}
+                className={`size-[40px] md:size-[55px] px-[14.52px] py-[7px] md:px-[22px] md:py-[14.5px] rounded-2xl border ${
+                  isActive ? 'bg-green-500 text-white border-green-500' : 'border-green-500'
+                }`}
+              >
+                {pageNumber}
+              </button>
+            );
+          })}
+          {/* 오른쪽 화살표 */}
+          <button
+            onClick={() => !isLastPage && onPageChange(currentPage + 1)}
+            disabled={isLastPage}
+            className={`size-[40px] md:size-[55px] flex  items-center justify-center rounded-2xl border text-sm pl-1 ${
+              isLastPage
+                ? 'border-gray-300 text-gray-300 cursor-not-allowed'
+                : 'border-green-500 text-green-500 hover:bg-green-500 hover:text-white'
+            }`}
+          >
+            ▶
+          </button>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-5 items-center mt-[85px]">
+          <Image
+            src="/ic_empty.svg"
+            alt="댓글없음"
+            className="md:w-[115px] md:h-[135px] mx-auto"
+            width={65}
+            height={88}
+          />
+          <div className="text-xl-medium text-gray-800">아직 등록된 댓글이 없어요</div>
+        </div>
+      )}
+    </>
   );
 }

--- a/components/domain/activityDetail/ReviewPagination.tsx
+++ b/components/domain/activityDetail/ReviewPagination.tsx
@@ -69,7 +69,7 @@ export default function ReviewPagination({
             width={65}
             height={88}
           />
-          <div className="text-xl-medium text-gray-800">아직 등록된 댓글이 없어요</div>
+          <div className="text-xl-medium text-gray-800">아직 등록된 후기가 없어요</div>
         </div>
       )}
     </>

--- a/public/ic_close_white.svg
+++ b/public/ic_close_white.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 10L30 30" stroke="#FAFAFA" stroke-width="2.5" stroke-linecap="round"/>
+<path d="M30 10L10 30" stroke="#FAFAFA" stroke-width="2.5" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## ✨ PR 개요

> 체험 상세 페이지 리팩토링, 이미지 섹션 개선, Dropdown 아이디 수정

## 🧩 PR 요약

- [x] 새로운 기능 추가
- [x] 버그 수정

## 🎯 작업 내용 상세 (요구사항 확인)

- [x]  Activity 상세 페이지 전체 너비 조정 및 통일
- [x] ActivityImgSection 코드 분리 → PC/Mobile 전용 뷰로 컴포넌트화
- [x] 이미지 클릭 시 모달 뷰어 (ModalImgViewer) 닫힘 처리
- [x] 후기 없는 경우 예외 UI 처리 (ic_empty.svg 표시)
- [x] 페이지네이션 내 이전/다음 버튼 hover 및 비활성화 스타일 개선
- [x] 케밥 메뉴 기존 useAuthStore → useUserStore로 사용자 아이디 수정
- [x] 이미지 모달의 화살표 항상 보이게 수정

## 📸 스크린샷 (선택)

> UI 변경이 있는 경우 추가

| 기능      | 스크린샷              |
| --------- | --------------------- |
| 서브이미지 0~4 | ![image](https://github.com/user-attachments/assets/50f00373-9d00-4975-a2da-69579fe40b0d) |
|  | ![image](https://github.com/user-attachments/assets/c799f75b-35e4-47fc-80ad-4db5b56f7b91) |
|  | ![image](https://github.com/user-attachments/assets/461149eb-c30b-4b79-bc8c-8ba1261b79f1) |
|  | ![image](https://github.com/user-attachments/assets/67587625-e2f3-4307-b5d2-76d1e63dde23) |
|  |![image](https://github.com/user-attachments/assets/78d52c8e-b3fa-4dbd-b932-dc1eb5f39507) |
| 후기 없는 경우 | ![image](https://github.com/user-attachments/assets/40780b1c-d615-4b23-b0bb-23352c926a4c) |

## 🔗 관련 이슈 (선택)

> #127 

## 💬 기타 전달 사항 (선택)

> 자잘한 스타일 리팩토링까지 함께 올리다보니 pr이 길어지게 됐습니다..😢