### PR TITLE
refactor: 내가 만든 체험일 경우 예약카드 안보이게 수정

### DIFF
--- a/app/(main)/activities/[activityId]/page.tsx
+++ b/app/(main)/activities/[activityId]/page.tsx
@@ -2,7 +2,7 @@ import ActivityDetailInfo from '@/components/domain/activityDetail/ActivityDetai
 import ActivityDetailReview from '@/components/domain/activityDetail/ActivityDetailReview';
 import ActivityMap from '@/components/domain/activityDetail/ActivityMap';
 import ActivityDescription from '@/components/domain/activityDetail/ActivityDescription';
-import ReservationSection from './ReservationSection';
+import ReservationClientWrapper from '@/components/domain/activityDetail/reservation/ReservationClientWrapper';
 import { getActivitiesId } from '@/services/activities';
 import React from 'react';
 
@@ -27,7 +27,7 @@ export default async function ActivityDetailPage({ params }: { params: Promise<{
           md:sticky md:top-0 md:left-auto md:w-auto md:shadow-none
         "
           >
-            <ReservationSection />
+            <ReservationClientWrapper activityUserId={data.userId} />
           </div>
         </div>
       </div>

--- a/components/domain/activityDetail/reservation/ReservationClientWrapper.tsx
+++ b/components/domain/activityDetail/reservation/ReservationClientWrapper.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import useUserStore from '@/store/useUserStore';
+import ReservationSection from '@/app/(main)/activities/[activityId]/ReservationSection';
+
+export default function ReservationClientWrapper({ activityUserId }: { activityUserId: number }) {
+  const { user } = useUserStore();
+  const isAuthor = user?.id !== activityUserId;
+
+  if (!isAuthor) return null;
+
+  return (
+    <div>
+      <ReservationSection />
+    </div>
+  );
+}


### PR DESCRIPTION
## ✨ PR 개요

> 검색 컴포넌트 생성 및 반응형 구현

## 🧩 PR 요약

- [x] 새로운 기능 추가
- [ ] 버그 수정

## 🎯 작업 내용 상세 (요구사항 확인)

- [x] ReservationSection을 ReservationClientWrapper로 감싸고, 클라이언트에서만 렌더링되도록 처리
- [x] 현재 로그인한 사용자의 id와 활동 작성자의 id를 비교해, 작성자가 아닐 경우에만 예약 섹션이 노출되도록 수정

## 📸 스크린샷 (선택)

> UI 변경이 있는 경우 추가

| 기능      | 스크린샷              |
| --------- | --------------------- |
| 팀생성 폼 | ![image](이미지 주소) |

## 🔗 관련 이슈 (선택)

> ex) #123 - 모달 UI 문제 이슈

## 💬 기타 전달 사항 (선택)

> 고민 중인 포인트나 논의가 필요한 부분이 있다면 작성해주세요.
