### PR TITLE
feat: 스켈레톤 추가 쿼리팩토리 패턴을 사용해서 일관된 쿼리키를 사용하도록 수정

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -6,7 +6,7 @@ import { getActivities } from '@/services/activities';
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
 import PopularActivitySection from '@/components/domain/mainPage/PopularActivitySection';
 import SearchHeader from '@/components/domain/mainPage/SearchHeader';
-import { SizeByDeviceType } from '@/hooks/useMainActivityList';
+import { activitiesKeys } from '@/lib/queryKeys';
 
 export interface ActivitySearchParams {
   method: 'offset' | 'cursor';
@@ -26,21 +26,27 @@ export default async function MainPage({ searchParams }: MainPageProps) {
   const queryClient = new QueryClient();
 
   const { keyword, category, sort, page } = await searchParams;
+  const size = 8;
 
-  let pageSize = SizeByDeviceType.desktop;
-  if (keyword) {
-    pageSize = pageSize * 2;
-  }
+  const popularListKey = activitiesKeys.popular();
+  const mainListKey = activitiesKeys.list({
+    keyword,
+    category,
+    sort,
+    page: page ? Number(page) : 1,
+    size,
+  });
 
-  const mainListParams: ActivitySearchParams = { method: 'offset', keyword, category, sort, page, size: pageSize };
+  //API요청에 사용될 파라미터 객체
+  const mainListParams = mainListKey[2];
 
-  const [popularData, mainListData] = await Promise.all([
-    getActivities({ method: 'offset', sort: 'most_reviewed', size: 9 }),
-    getActivities(mainListParams),
+  const [, mainListData] = await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: popularListKey,
+      queryFn: () => getActivities({ method: 'offset', sort: 'most_reviewed', size: 9 }),
+    }),
+    queryClient.fetchQuery({ queryKey: mainListKey, queryFn: () => getActivities(mainListParams) }),
   ]);
-
-  queryClient.setQueryData(['activities', 'popularList'], popularData);
-  queryClient.setQueryData(['activities', mainListParams], mainListData);
 
   const totalCount = mainListData.totalCount;
 

--- a/components/domain/mainPage/SearchHeader.tsx
+++ b/components/domain/mainPage/SearchHeader.tsx
@@ -2,7 +2,7 @@ import { getKoreanJosa } from '@/lib/getKoreanJosa';
 
 interface SearchHeaderProps {
   keyword: string;
-  searchResultCount: number;
+  searchResultCount: number | undefined;
 }
 
 export default function SearchHeader({ keyword, searchResultCount }: SearchHeaderProps) {

--- a/components/domain/mainPage/activityList/MainActivityList.tsx
+++ b/components/domain/mainPage/activityList/MainActivityList.tsx
@@ -4,28 +4,42 @@ import useMainActivityList from '@/hooks/useMainActivityList';
 import MainPageBasicActivity from './MainPageBasicActivity';
 import Link from 'next/link';
 import MainPagination from './MainPagination';
+import MainPageActivitySkeleton from './skeleton/MainPageActivitySkeleton';
 
-const listClasses =
+const baseGridClasses =
   'grid grid-cols-2 grid-rows-2 gap-2 md:grid-cols-3 md:grid-rows-3 md:gap-x-4 md:gap-y-8 lg:grid-cols-4 lg:grid-rows-2 lg:gap-x-6 lg:gap-y-12';
+
+const searchGridClasses =
+  'grid grid-cols-2 grid-rows-4 gap-2 md:grid-cols-3 md:grid-rows-3 md:gap-x-4 md:gap-y-8 lg:grid-cols-4 lg:grid-rows-4 lg:gap-x-6 lg:gap-y-12';
 
 interface MainActivityListProps {
   totalCount: number | undefined;
 }
 
 export default function MainActivityList({ totalCount }: MainActivityListProps) {
-  const { activities, hasKeyword } = useMainActivityList();
+  const { activities, hasKeyword, isPending, size } = useMainActivityList();
 
   return (
     <section className={`${hasKeyword ? 'mt-6' : 'mt-6 md:mt-8'} min-h-screen pb-20`}>
-      <ul className={listClasses}>
-        {activities.map(activity => (
-          <li key={activity.id}>
-            <Link href={`/activities/${activity.id}`}>
-              <MainPageBasicActivity activity={activity} />
-            </Link>
-          </li>
-        ))}
-        <MainPagination totalCount={totalCount} />
+      <ul className={hasKeyword ? searchGridClasses : baseGridClasses}>
+        {isPending ? (
+          Array.from({ length: size }).map((_, index) => (
+            <li key={`skeleton-${index}`}>
+              <MainPageActivitySkeleton />
+            </li>
+          ))
+        ) : (
+          <>
+            {activities.map(activity => (
+              <li key={activity.id}>
+                <Link href={`/activities/${activity.id}`}>
+                  <MainPageBasicActivity activity={activity} />
+                </Link>
+              </li>
+            ))}
+          </>
+        )}
+        {activities.length > 0 && <MainPagination totalCount={totalCount} />}
       </ul>
     </section>
   );

--- a/components/domain/mainPage/activityList/skeleton/MainPageActivitySkeleton.tsx
+++ b/components/domain/mainPage/activityList/skeleton/MainPageActivitySkeleton.tsx
@@ -1,0 +1,15 @@
+export default function MainPageActivitySkeleton() {
+  return (
+    <div className="flex flex-col gap-4 animate-pulse">
+      <div className="rounded-[20px] w-full h-auto aspect-square bg-gray-200" />
+      <div className="flex flex-col gap-3">
+        <div className="flex gap-1">
+          <div className="h-5 w-1/4 bg-gray-200 rounded" />
+          <div className="h-5 w-1/4 bg-gray-200 rounded" />
+        </div>
+        <div className="h-6 w-full bg-gray-200 rounded" />
+        <div className="h-7 w-1/2 bg-gray-200 rounded mt-2" />
+      </div>
+    </div>
+  );
+}

--- a/constants/sizeByDeviceType.ts
+++ b/constants/sizeByDeviceType.ts
@@ -1,0 +1,5 @@
+export enum SizeByDeviceType {
+  mobile = 4,
+  tablet = 9,
+  desktop = 8,
+}

--- a/hooks/usePagination.ts
+++ b/hooks/usePagination.ts
@@ -1,8 +1,8 @@
 'use client';
 
+import { SizeByDeviceType } from '@/constants/sizeByDeviceType';
 import useMediaQuery from '@/store/useMediaQuery';
 import { useSearchParams } from 'next/navigation';
-import { SizeByDeviceType } from './useMainActivityList';
 
 export default function usePagination(totalCount: number | undefined) {
   const deviceType = useMediaQuery();

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -1,0 +1,25 @@
+import { ActivitySearchParams } from '@/app/(main)/page';
+
+type ActivityListParams = Omit<ActivitySearchParams, 'method' | 'cursorId'>;
+
+export const activitiesKeys = {
+  all: ['activities'] as const,
+  lists: () => [...activitiesKeys.all, 'list'] as const,
+
+  // 파라미터를 받아 일관된 형식의 쿼리 키를 생성하는 함수
+  list: (params: ActivityListParams) => {
+    // 이 함수에서 파라미터를 표준화하여 일관성을 보장합니다.
+    const searchParams: ActivitySearchParams = {
+      method: 'offset',
+      size: params.size || 16,
+      page: Number(params.page) || 1, // page가 없거나 0이면 기본값 1로 설정
+      sort: params.sort || 'latest', // sort가 없으면 기본값 'latest'로 설정 (혹은 undefined)
+      category: params.category || undefined,
+      keyword: params.keyword || undefined,
+    };
+    return [...activitiesKeys.lists(), searchParams] as const;
+  },
+
+  // 인기 체험 리스트를 위한 키
+  popular: () => [...activitiesKeys.all, 'popularList'] as const,
+};


### PR DESCRIPTION
## 문제인식
- RSC에서 데이터 패칭 후 클라이언트에서 반응형 감지를 통해 모바일이나 태블릿 환경에서 데이터 패칭를 새로 진행하게 되는 점
- 그로 인해 다시 로드하게 되어 사용자 경험에 별로 좋지 않은 영향을 줌

## 문제 해결 노력
1. 일단 서버와 클라이언트가 일치되는 쿼리키를 갖도록 쿼리팩토리 패턴을 도입해서 쿼리키 관리 https://www.mintmin.dev/blog/2402/20240226
https://5kdk.github.io/blog/2025/04/04/query-factory
(참고 자료)
2. 반응형으로 인해서 쿼리키가 달라지게 되어 서버에서 데이터 패칭을 해도 다시 불러오게 됨 (모바일이나 태블릿에서) 그래서 처음에 최대값이 16개의 데이터를 불러오고 css로 잘라서 보여지게 하려고 함 -> 페이지네이션 로직과 불일치로 인한 실패
3. 미들웨어에서 헤더를 통해 클라이언트 힌트를 받아 서버에서도 반응형 처리를 하려고 함 -> 클라이언트 힌트 자체의 불안전성, 그리고 최초 데이터 패칭 이후엔 큰 의미가 없는 듯함
4. 현재 상황 스켈레톤 UI를 추가해서 데이터 패칭이 반복되더라도 사용자가 느끼는 경험을 조금 낫게 하려고 함..

<img width="2672" alt="스크린샷 2025-06-18 오전 3 05 32" src="https://github.com/user-attachments/assets/36eaf599-e9c0-4f71-aa25-0b97169507e7" />

