### PR TITLE
[Feat] 체험 상세 예약 달력 날짜, 시간 지나면 선택하지 못하도록, 예약 가능 시간 점으로 표시

### DIFF
--- a/app/(main)/activities/[activityId]/ReservationSection.tsx
+++ b/app/(main)/activities/[activityId]/ReservationSection.tsx
@@ -18,6 +18,11 @@ export default function ReservationSection() {
   const [count, setCount] = useState(1);
   const { openModal, closeModal } = useModalStore();
 
+  const today = new Date();
+  const year = format(today, 'yyyy');
+  const month = format(today, 'MM');
+  const formattedDate = date ? format(date, 'yyyy-MM-dd') : '';
+
   //체험 상세 정보 불러오기 -> 가격 포함
   const { data: activityData } = useQuery({
     queryKey: ['activity', id],
@@ -25,22 +30,20 @@ export default function ReservationSection() {
     enabled: !!id,
   });
 
-  //날짜 바뀌었을 때 해당 날짜의 예약 시간 불러오기
-
-  const year = date ? format(date, 'yyyy') : '';
-  const month = date ? format(date, 'MM') : '';
-  const formattedDate = date ? format(date, 'yyyy-MM-dd') : '';
-
   const { data: scheduleData } = useQuery({
     queryKey: ['availableSchedule', id, year, month],
     queryFn: () => getAvailableSchedule({ activityId: id, year, month }),
-    enabled: !!id && !!date,
+    enabled: !!id,
   });
 
   const matchedDay = scheduleData?.find(d => d.date === formattedDate);
   console.log('matchedDay:', matchedDay);
 
-  const availableTimes = matchedDay?.times.map(t => ({ startTime: t.startTime, endTime: t.endTime })) ?? [];
+  const availableTimes =
+    matchedDay?.times.map(t => ({
+      startTime: t.startTime,
+      endTime: t.endTime,
+    })) ?? [];
   console.log('예약 가능한 시간:', availableTimes);
 
   //예약 요청
@@ -75,6 +78,8 @@ export default function ReservationSection() {
     return <p className="text-center py-10">가격 정보를 불러오는 중입니다...</p>;
   }
 
+  const availableDates = scheduleData?.map(d => d.date) ?? [];
+
   return (
     <ReservationBox
       state={{ date, time, count }}
@@ -84,6 +89,8 @@ export default function ReservationSection() {
       onReserve={handleReserve}
       pricePerPerson={pricePerPerson}
       availableTimes={availableTimes}
+      availableDates={availableDates}
+      scheduleData={scheduleData}
     />
   );
 }

--- a/components/common/DatePicker.tsx
+++ b/components/common/DatePicker.tsx
@@ -1,18 +1,20 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { DayPicker } from 'react-day-picker';
-import { format, addMonths, subMonths } from 'date-fns';
+import { format, addMonths, subMonths, parseISO } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import 'react-day-picker/style.css';
 
 interface DatePickerProps {
   selected: Date | undefined;
   onSelect: (date: Date | undefined) => void;
+  availableDates: string[];
 }
 
-export default function DatePicker({ selected, onSelect }: DatePickerProps) {
+export default function DatePicker({ selected, onSelect, availableDates }: DatePickerProps) {
   const [month, setMonth] = useState(new Date());
+  const availableDateObjects = useMemo(() => availableDates.map(dateStr => parseISO(dateStr)), [availableDates]);
 
   return (
     <div className="z-[9999] bg-white space-y-2 rounded-lg border border-gray-200 py-2.5 w-[305px] h-[241px]">
@@ -42,6 +44,7 @@ export default function DatePicker({ selected, onSelect }: DatePickerProps) {
         onSelect={onSelect}
         showOutsideDays
         locale={ko}
+        disabled={{ before: new Date() }}
         /* eslint-disable camelcase */
         classNames={{
           root: '',
@@ -54,10 +57,16 @@ export default function DatePicker({ selected, onSelect }: DatePickerProps) {
           weekday: 'text-sm font-bold text-[#4b4b4b]',
           month_grid: 'w-full',
         }}
+        modifiers={{
+          reservable: availableDateObjects,
+        }}
         modifiersClassNames={{
           selected: '!bg-[#0b3b2d] !text-white rounded-lg',
           today: 'bg-[#ced8d5] text-[#0b3b2d] rounded-lg',
           outside: 'text-[#A4A1AA]',
+          disabled: 'text-gray-400 line-through cursor-not-allwed',
+          reservable:
+            'after:block after:w-1.5 after:h-1.5 after:rounded-full after:bg-[#00b894] after:mt-1 after:mx-auto',
         }}
       />
     </div>

--- a/components/domain/activityDetail/reservation/ReservationBox.tsx
+++ b/components/domain/activityDetail/reservation/ReservationBox.tsx
@@ -22,7 +22,12 @@ interface ReservationBoxProps {
   onReserve: () => void;
   pricePerPerson: number;
   availableTimes: { startTime: string; endTime: string }[];
+  availableDates: string[];
   loading?: boolean;
+  scheduleData?: {
+    date: string;
+    times: { startTime: string; endTime: string; id: number }[];
+  }[];
 }
 
 export default function ReservationBox({
@@ -33,6 +38,8 @@ export default function ReservationBox({
   onReserve,
   pricePerPerson,
   availableTimes,
+  availableDates,
+  scheduleData,
   loading = false,
 }: ReservationBoxProps) {
   const device = useMediaQuery();
@@ -49,6 +56,7 @@ export default function ReservationBox({
             onCountChange={onCountChange}
             onReserve={onReserve}
             availableTimes={availableTimes}
+            availableDates={availableDates}
             loading={loading}
             onClose={() => setIsMobileFormOpen(false)}
           />
@@ -77,7 +85,9 @@ export default function ReservationBox({
         onReserve={onReserve}
         pricePerPerson={pricePerPerson}
         availableTimes={availableTimes}
+        availableDates={availableDates}
         loading={loading}
+        scheduleData={scheduleData}
       />
     );
   }
@@ -90,6 +100,7 @@ export default function ReservationBox({
       onTimeChange={onTimeChange}
       onReserve={onReserve}
       pricePerPerson={pricePerPerson}
+      availableDates={availableDates}
       availableTimes={availableTimes}
       loading={loading}
     />

--- a/components/domain/activityDetail/reservation/ReservationMobile.tsx
+++ b/components/domain/activityDetail/reservation/ReservationMobile.tsx
@@ -20,6 +20,7 @@ interface ReservationMobileProps {
   onReserve: () => void;
   onClose: () => void;
   availableTimes: { startTime: string; endTime: string }[];
+  availableDates: string[];
   loading?: boolean;
 }
 
@@ -30,6 +31,7 @@ export default function ReservationMobile({
   onCountChange,
   onClose,
   availableTimes,
+  availableDates,
   loading = false,
 }: ReservationMobileProps) {
   const [step, setStep] = useState<1 | 2>(1);
@@ -65,7 +67,7 @@ export default function ReservationMobile({
       <div className="flex-1 overflow-hidden px-4">
         {step === 1 && (
           <>
-            <DateSelector date={state.date} onSelect={onDateChange} />
+            <DateSelector date={state.date} onSelect={onDateChange} availableDates={availableDates} />
 
             {state.date && (
               <div className="mt-6">
@@ -76,6 +78,7 @@ export default function ReservationMobile({
                     selected={state.time}
                     onChange={onTimeChange}
                     disabled={loading}
+                    date={state.date}
                   />
                 ) : (
                   <p className="text-sm text-gray-500">예약 가능한 시간이 없습니다.</p>

--- a/components/domain/activityDetail/reservation/ReservationPC.tsx
+++ b/components/domain/activityDetail/reservation/ReservationPC.tsx
@@ -19,6 +19,7 @@ interface ReservationPCProps {
   onReserve: () => void;
   pricePerPerson: number;
   availableTimes: { startTime: string; endTime: string }[];
+  availableDates: string[];
   loading?: boolean;
 }
 
@@ -31,6 +32,7 @@ export default function ReservationPC({
   pricePerPerson,
   loading = false,
   availableTimes,
+  availableDates,
 }: ReservationPCProps) {
   const isReservable = !!state.date && state.time;
 
@@ -50,14 +52,20 @@ export default function ReservationPC({
 
       <div className="mb-6">
         <span className="block text-black mb-3 text-2lg-bold">날짜</span>
-        <DateSelector date={state.date} onSelect={onDateChange} />
+        <DateSelector date={state.date} onSelect={onDateChange} availableDates={availableDates} />
       </div>
 
       {state.date && (
         <div className="mb-6">
           <span className="block text-black mb-2 text-2lg-bold">예약 가능한 시간</span>
           {availableTimes.length > 0 ? (
-            <TimeSelector times={availableTimes} selected={state.time} onChange={onTimeChange} disabled={loading} />
+            <TimeSelector
+              times={availableTimes}
+              selected={state.time}
+              onChange={onTimeChange}
+              disabled={loading}
+              date={state.date}
+            />
           ) : (
             <p className="text-sm text-gray-500">예약 가능한 시간이 없습니다.</p>
           )}

--- a/components/domain/activityDetail/reservation/ReservationTablet.tsx
+++ b/components/domain/activityDetail/reservation/ReservationTablet.tsx
@@ -21,6 +21,11 @@ interface ReservationTabletProps {
   pricePerPerson: number;
   availableTimes: { startTime: string; endTime: string }[];
   loading?: boolean;
+  availableDates: string[];
+  scheduleData?: {
+    date: string;
+    times: { startTime: string; endTime: string; id: number }[];
+  }[];
 }
 
 export default function ReservationTablet({
@@ -30,8 +35,10 @@ export default function ReservationTablet({
   onCountChange,
   onReserve,
   pricePerPerson,
+  availableDates,
   loading = false,
   availableTimes,
+  scheduleData,
 }: ReservationTabletProps) {
   const { openModal } = useModalStore();
   const isReservable = !!state.date && state.time;
@@ -63,7 +70,9 @@ export default function ReservationTablet({
                   onTimeChange,
                   onReserve,
                   availableTimes,
+                  availableDates,
                   loading,
+                  scheduleData,
                 })
               }
               className="text-black hover:underline cursor-pointer text-sm"

--- a/components/domain/activityDetail/reservation/parts/DateSelector.tsx
+++ b/components/domain/activityDetail/reservation/parts/DateSelector.tsx
@@ -5,12 +5,13 @@ import DatePicker from '@/components/common/DatePicker';
 interface DateSelectorProps {
   date: Date | undefined;
   onSelect: (date: Date | undefined) => void;
+  availableDates: string[];
 }
 
-export default function DateSelector({ date, onSelect }: DateSelectorProps) {
+export default function DateSelector({ date, onSelect, availableDates }: DateSelectorProps) {
   return (
     <div className="flex justify-center">
-      <DatePicker selected={date} onSelect={onSelect} />
+      <DatePicker selected={date} onSelect={onSelect} availableDates={availableDates} />
     </div>
   );
 }

--- a/components/domain/activityDetail/reservation/parts/TimeSelector.tsx
+++ b/components/domain/activityDetail/reservation/parts/TimeSelector.tsx
@@ -1,5 +1,6 @@
 //시간선택
 import clsx from 'clsx';
+import { format } from 'date-fns';
 
 interface TimeSlot {
   startTime: string;
@@ -11,36 +12,51 @@ export default function TimeSelector({
   selected,
   onChange,
   disabled,
+  date,
 }: {
   times: TimeSlot[];
   selected: string;
   onChange: (startTime: string) => void;
   disabled?: boolean;
+  date?: Date;
 }) {
+  const now = new Date();
+  const isPast = (startTime: string) => {
+    if (!date) return false;
+    const timeStart = new Date(`${format(date, 'yyyy-MM-dd')}T${startTime}`);
+    return timeStart < now;
+  };
+
   return (
     <div className="flex gap-3 overflow-x-auto">
-      {times.map(({ startTime, endTime }) => (
-        <label
-          key={startTime}
-          className={clsx(
-            'flex items-center justify-center text-lg-medium border rounded-lg px-4 py-2 cursor-pointer transition w-[117px] mb-2',
-            selected === startTime
-              ? 'bg-black text-lg-medium text-white border-black'
-              : 'bg-white text-black text-lg-medium border-black',
-            'hover:border-black',
-          )}
-        >
-          <input
-            type="radio"
-            checked={selected === startTime}
-            onChange={() => onChange(startTime)}
-            disabled={disabled}
-            name="reserve-time"
-            className="hidden"
-          />
-          {`${startTime}~${endTime}`}
-        </label>
-      ))}
+      {times.map(({ startTime, endTime }) => {
+        const timePassed = isPast(startTime);
+        const isDisabled = disabled || timePassed;
+
+        return (
+          <label
+            key={startTime}
+            className={clsx(
+              'flex items-center justify-center text-lg-medium border rounded-lg px-4 py-2 cursor-pointer transition w-[117px] mb-2',
+              selected === startTime
+                ? 'bg-black text-lg-medium text-white border-black'
+                : 'bg-white text-black text-lg-medium border-black',
+              'hover:border-black',
+              isDisabled && 'text-gray-400 line-through bg-gray-100 cursor-not-allowed border-gray-400',
+            )}
+          >
+            <input
+              type="radio"
+              checked={selected === startTime}
+              onChange={() => onChange(startTime)}
+              disabled={isDisabled}
+              name="reserve-time"
+              className="absolute opacity-0 w-0 h-0"
+            />
+            {`${startTime}~${endTime}`}
+          </label>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## ✨ PR 개요

> 체험 상세 예약 달력 날짜, 시간 시간 지나면 선택하지 못하도록, 예약 가능 시간 점으로 표시

## 🧩 PR 요약

- [x] 새로운 기능 추가
- [ ] 버그 수정

## 🎯 작업 내용 상세 (요구사항 확인)

- [x] 체험 상세 예약 달력 날짜, 시간 시간 지나면 선택하지 못하도록, 예약 가능 시간 점으로 표시

## 📸 스크린샷 (선택)

> UI 변경이 있는 경우 추가

<img width="281" alt="image" src="https://github.com/user-attachments/assets/02bfc60f-762d-4420-a53c-08a0f3c9a493" />

- 예약 가능한 시간 있으면 초록점으로 달력에 표시
- 해당 날짜에 예약 시간이 지나면 시간 비활성화
- 해당 날짜가 지나면 해당 날짜 비활성화

## 🔗 관련 이슈 (선택)

> ex) #123 - 모달 UI 문제 이슈

## 💬 기타 전달 사항 (선택)

> 고민 중인 포인트나 논의가 필요한 부분이 있다면 작성해주세요.
