### PR TITLE
fix: 삭제 기능 오류 수정

### DIFF
--- a/components/domain/activityDetail/DropdownActivityDetail.tsx
+++ b/components/domain/activityDetail/DropdownActivityDetail.tsx
@@ -2,7 +2,7 @@
 import DropdownMenu from '@/components/common/DropDown';
 import Image from 'next/image';
 import { delMyActivities } from '@/services/myActivities';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import TwoButtonModal from '@/components/common/modal/TwoButtonModal';
 import { useModalStore } from '@/store/modalStore';
 import useUserStore from '@/store/useUserStore';
@@ -15,6 +15,7 @@ type DropDownActivityDetailProps = {
 export default function DropDownActivityDetail({ userId, activityId }: DropDownActivityDetailProps) {
   const { user } = useUserStore();
   const router = useRouter();
+  const pathname = usePathname();
   const { openModal } = useModalStore();
 
   const isAuthor = user?.id === userId;
@@ -25,7 +26,12 @@ export default function DropDownActivityDetail({ userId, activityId }: DropDownA
 
   const handleDeleteActivity = async () => {
     await delMyActivities(activityId);
-    router.refresh(); // 삭제 후 새로고침
+    const isOnActivityDetailPage = /^\/activities\/\d+$/.test(pathname); //현재 경로가 '/activities/'로 시작하고, 그 뒤에 숫자가 오는 패턴인지 확인
+    if (isOnActivityDetailPage) {
+      router.back(); // 체험 상세 페이지에 있다면 뒤로 가기
+    } else {
+      router.refresh();
+    }
   };
 
   const openDeleteModal = () => {


### PR DESCRIPTION
## ✨ PR 개요

> 삭제 기능 오류 수정

## 🧩 PR 요약

- [ ] 새로운 기능 추가
- [x] 버그 수정

## 🎯 작업 내용 상세 (요구사항 확인)

- [x] 본문 처리 시, content-length를 체크하여 본문이 없을 경우 불필요한 파싱 방지
- [x] 상태 코드가 204 No Content인 경우 본문 없이 NextResponse 반환하도록 처리
- [x] 삭제 기능 수행 후, 현재 페이지가 상세 페이지(/activities/:id)인 경우 router.back()으로 뒤로 이동, 그 외에는 router.refresh() 처리

## 📸 스크린샷 (선택)

> UI 변경이 있는 경우 추가

| 기능      | 스크린샷              |
| --------- | --------------------- |
| 팀생성 폼 | ![image](이미지 주소) |

## 🔗 관련 이슈 (선택)

> ex) #123 - 모달 UI 문제 이슈

## 💬 기타 전달 사항 (선택)

> 체험 상세 페이지에서 삭제 시 UX 향상을 위해 뒤로 이동 처리
> `if (req.method !== 'GET' && req.method !== 'HEAD')` -> DELETE 요청이 이 조건을 통과함 -> `body = JSON.stringify(await req.json());` -> DELET 요청은 본문이 없는데, 여기에서 본문을 읽으려해서 에러 발생
=>  실제로 본문이 있는지 확인하는 로직을 추가 `const contentLength = req.headers.get('content-length');
      if (contentLength && parseInt(contentLength, 10) > 0) {`
> 204 응답 처리 추가 
`if (response.status === 204) {
    return new NextResponse(null, { status: 204, statusText: response.statusText });
  }`
