### PR TITLE
fix: 내정보 업데이트 시, gnb profile 영역 업데이트

### DIFF
--- a/components/common/gnb/ProfileButton.tsx
+++ b/components/common/gnb/ProfileButton.tsx
@@ -56,8 +56,8 @@ export default function ProfileButton() {
               <Image
                 src={user.profileImage ?? profileIcon}
                 alt="프로필"
-                width={12}
-                height={12}
+                width={32}
+                height={32}
                 className="w-6 h-6 sm:w-8 sm:h-8 rounded-full"
               />
               <span className="text-sm truncate whitespace-nowrap overflow-hidden min-w-0">{user.name}</span>

--- a/components/domain/profile/MyInfoForm.tsx
+++ b/components/domain/profile/MyInfoForm.tsx
@@ -7,6 +7,7 @@ import { useForm, SubmitHandler, Controller } from 'react-hook-form';
 import { getUserMe, patchUserMe } from '@/services/users';
 import { UpdateUserBodyDto } from '@/types';
 import { GetMyInfoSuccessResponse } from '@/types/domain/user/types';
+import useUserStore from '@/store/useUserStore';
 import { useModalStore } from '@/store/modalStore';
 import Input from '@/components/common/Input';
 import SkeletonMyInfoForm from '@/components/skeleton/SkeletonMyInfoForm';
@@ -23,6 +24,7 @@ type userInfoInputs = UpdateUserBodyDto & {
 export default function MyInfoPage() {
   const queryClient = useQueryClient();
   const { openModal } = useModalStore();
+  const { setUser } = useUserStore();
 
   const [email, setEmail] = useState('');
   const [showPassword, setShowPassword] = useState(false);
@@ -58,8 +60,16 @@ export default function MyInfoPage() {
     mutationFn: profileInfo => {
       return patchUserMe(profileInfo);
     },
-    onSuccess: () => {
+    onSuccess: data => {
       queryClient.invalidateQueries({ queryKey: ['myInfo'] });
+
+      setUser({
+        id: data.id,
+        name: data.nickname,
+        profileImage: data.profileImageUrl ?? undefined,
+        teamId: 14 - 3,
+        accessToken: '',
+      });
       openModal(OneButtonModal, {
         content: '내정보가 수정되었습니다.',
         onConfirm: () => {},


### PR DESCRIPTION
## ✨ PR 개요

> 내정보 업데이트 시, gnb profile 영역 업데이트

## 🧩 PR 요약

- [] 새로운 기능 추가
- [x] 버그 수정

## 🎯 작업 내용 상세 (요구사항 확인)

- [x] 프로필 이미지 업로드 영역에서 이미지 업로드 시, gnb 프로필 이미지 영역에 반영됨
- [x] 내정보 페이지에서 내정보 수정하면, 수정한 내용이 gnb 프로필 영역에 반영됨

## 🔗 관련 이슈 (선택)

> ex) #123 - 모달 UI 문제 이슈

## 💬 기타 전달 사항 (선택)

> 고민 중인 포인트나 논의가 필요한 부분이 있다면 작성해주세요.
