### PR TITLE
[Refactor] 스크롤탑 전역 적용 및 내 체험 스타일 수정

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import GNB from '@/components/common/gnb/Gnb';
 import Footer from '@/components/common/Footer';
+import ScrollToTopButton from '@/components/common/ScrollTopButton';
 
 export default function MainLayout({ children }: { children: ReactNode }) {
   return (
@@ -8,6 +9,7 @@ export default function MainLayout({ children }: { children: ReactNode }) {
       <GNB />
       <main className="pt-[60px]">{children}</main>
       <Footer />
+      <ScrollToTopButton />
     </>
   );
 }

--- a/app/(main)/profile/activities/[activityId]/edit/page.tsx
+++ b/app/(main)/profile/activities/[activityId]/edit/page.tsx
@@ -423,7 +423,7 @@ export default function ActivityEditPage() {
           <button
             type="button"
             onClick={handleAddForm}
-            className="w-16 bg-green-500 text-white py-1 rounded hover:bg-green-600 text-[29px]"
+            className="w-16 bg-nomad-black text-white py-1 rounded hover:bg-green-500 text-[29px]"
           >
             +
           </button>
@@ -559,7 +559,7 @@ export default function ActivityEditPage() {
             ))}
           </div>
         </>
-        <button type="submit" className="w-full bg-green-500 text-white py-2 rounded hover:bg-green-600">
+        <button type="submit" className="w-full bg-nomad-black text-white py-2 rounded hover:bg-green-500">
           저장
         </button>
       </form>

--- a/app/(main)/profile/activities/new/page.tsx
+++ b/app/(main)/profile/activities/new/page.tsx
@@ -363,7 +363,7 @@ export default function NewAndEditActivityPage() {
           <button
             type="button"
             onClick={handleAddForm}
-            className="w-16 bg-green-500 text-white py-1 rounded hover:bg-green-600 text-[29px]"
+            className="w-16 bg-nomad-black text-white py-1 rounded hover:bg-green-500 text-[29px]"
           >
             +
           </button>
@@ -506,7 +506,7 @@ export default function NewAndEditActivityPage() {
           </div>
         </>
 
-        <button type="submit" className="w-full bg-green-500 text-white py-2 rounded hover:bg-green-600">
+        <button type="submit" className="w-full bg-nomad-black text-white py-2 rounded hover:bg-green-500">
           저장
         </button>
       </form>

--- a/app/(main)/profile/activities/page.tsx
+++ b/app/(main)/profile/activities/page.tsx
@@ -65,11 +65,11 @@ export default function ActivityManagePage() {
   }, [hasNextPage, fetchNextPage, isFetchingNextPage]);
 
   return (
-    <div className="mb-6 ml-6 mt-8">
+    <div className="mb-6 ml-4">
       <div className="flex items-center justify-between mb-4 max-w-full md:max-w-[600px] lg:max-w-[1000px]">
         <h1 className="text-xl-bold md:text-2xl-bold lg:text-3xl-bold mb-2 mt-1">내 체험 관리</h1>
         <Link href="/profile/activities/new">
-          <button className="bg-nomad-black hover:bg-green-500 transition-colirs duration-200 text-white px-4 py-2 rounded shadow">
+          <button className="bg-nomad-black hover:bg-green-500 transition-colors duration-200 text-white px-4 py-2 rounded shadow">
             체험 등록하기
           </button>
         </Link>

--- a/components/common/ScrollTopButton.tsx
+++ b/components/common/ScrollTopButton.tsx
@@ -22,7 +22,7 @@ export default function ScrollToTopButton() {
   return (
     <button
       onClick={scrollToTop}
-      className={`fixed bottom-4 right-6 z-50 w-10 h-10 bg-green-500 transition-all duration-300 rounded-full flex items-center justify-center ${
+      className={`fixed bottom-4 right-12 z-50 w-10 h-10 bg-green-700 transition-all duration-300 rounded-full flex items-center justify-center ${
         isVisible ? 'translate-x-0 opacity-100' : 'translate-x-8 opacity-0 pointer-events-none'
       }`}
     >

--- a/components/domain/activity/ActivityCard.tsx
+++ b/components/domain/activity/ActivityCard.tsx
@@ -31,7 +31,7 @@ export default function ActivityCard({ title, img, price, rating, reviewCount, u
 
           {userId !== null && (
             <div className="self-end">
-              <div className="w-[40px] h-[40px] flex items-center justify-center">
+              <div className="w-[40px] h-[40px] flex items-center justify-center cursor-pointer">
                 <DropDownActivityDetail userId={userId} activityId={id} />
               </div>
             </div>

--- a/components/domain/reservation/ClientReservations.tsx
+++ b/components/domain/reservation/ClientReservations.tsx
@@ -13,7 +13,6 @@ import ComponentSpinner from '@/components/common/spinners/ComponentSpinner';
 import { filterOptions } from '@/constants/filterOption';
 import { getMyReservations } from '@/services/myReservations';
 import useObserver from '@/hooks/useObserver';
-import ScrollToTopButton from '@/components/common/ScrollTopButton';
 
 import { wait } from '@/constants/utils/wait';
 
@@ -134,7 +133,6 @@ export default function ClientReservations() {
         </DropdownMenu>
       </div>
       {renderContent()}
-      <ScrollToTopButton />
     </div>
   );
 }


### PR DESCRIPTION
## ✨ PR 개요
내 체험 관리 UI 개선 및 스타일 리팩토링

## 🧩 PR 요약

- [x] 스타일 통일
- [x]  UI 개선

## 🎯 작업 내용 상세 (요구사항 확인)

- [x] 내 체험 관리 페이지 제목 스타일 수정
- [x] 케밥 메뉴 영역에 cursor-pointer 추가
- [x] 버튼 호버 시 색상 bg-green-500으로 통일 (bg-nomad-black --> hover:bg-green-500)
- [x] 전반적인 UI 스타일 일관성으로 바꿈
- [x] 스크롤탑 전역으로 적용

## 📸 스크린샷 (선택)
![체험 관리 제목 수정](https://github.com/user-attachments/assets/3afdb0e7-1868-4162-b333-1fb32c0c5c10)

## 🔗 관련 이슈 (선택)

> ex) #123 - 모달 UI 문제 이슈

## 💬 기타 전달 사항 (선택)
스타일 일관성을 위한 hover:bg-green-500 규칙을 글로벌 기준으로 적용했습니다.

